### PR TITLE
Fix the parameter `size` in test_pipeline

### DIFF
--- a/configs/_base_/datasets/imagenet_bs32.py
+++ b/configs/_base_/datasets/imagenet_bs32.py
@@ -13,7 +13,7 @@ train_pipeline = [
 ]
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='Resize', size=256),
+    dict(type='Resize', size=(256, -1)),
     dict(type='CenterCrop', crop_size=224),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),

--- a/configs/_base_/datasets/imagenet_bs32_pil_resize.py
+++ b/configs/_base_/datasets/imagenet_bs32_pil_resize.py
@@ -13,7 +13,7 @@ train_pipeline = [
 ]
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='Resize', size=256, backend='pillow'),
+    dict(type='Resize', size=(256, -1), backend='pillow'),
     dict(type='CenterCrop', crop_size=224),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),

--- a/configs/_base_/datasets/imagenet_bs64.py
+++ b/configs/_base_/datasets/imagenet_bs64.py
@@ -13,7 +13,7 @@ train_pipeline = [
 ]
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='Resize', size=256),
+    dict(type='Resize', size=(256, -1)),
     dict(type='CenterCrop', crop_size=224),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),

--- a/configs/_base_/datasets/imagenet_bs64_pil_resize.py
+++ b/configs/_base_/datasets/imagenet_bs64_pil_resize.py
@@ -13,7 +13,7 @@ train_pipeline = [
 ]
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='Resize', size=256, backend='pillow'),
+    dict(type='Resize', size=(256, -1), backend='pillow'),
     dict(type='CenterCrop', crop_size=224),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),


### PR DESCRIPTION
Fix the parameter `size` of test_pipeline() in 'configs/base/datasets/*.py'. According to the docstring in https://github.com/open-mmlab/mmclassification/blob/408d92bcbe5f83c296e31ca0128b3d6521da7055/mmcls/datasets/pipelines/transforms.py#L336, we have to set `size=(256, -1)` to resize the short edge to 256 before center cropping.