### PR TITLE
Fix crash in CenterCrop transform when image is greyscale

### DIFF
--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -436,7 +436,8 @@ class CenterCrop(object):
         crop_height, crop_width = self.crop_size[0], self.crop_size[1]
         for key in results.get('img_fields', ['img']):
             img = results[key]
-            img_height, img_width, _ = img.shape
+            # img.shape has length 2 for grayscale, length 3 for color
+            img_height, img_width = img.shape[:2]
 
             y1 = max(0, int(round((img_height - crop_height) / 2.)))
             x1 = max(0, int(round((img_width - crop_width) / 2.)))


### PR DESCRIPTION
CenterCrop transform currently crashes when the image is greyscale. This is because image shape has length 3 when the image is color but length two when the image is greyscale. The third element wasn't being used in either case, so this pull request modifies the code such that only the first two elements of image shape are unpacked.