### PR TITLE
Remove accuracy from foward train

### DIFF
--- a/mmcls/models/heads/cls_head.py
+++ b/mmcls/models/heads/cls_head.py
@@ -1,4 +1,3 @@
-from mmcls.models.losses import Accuracy
 from ..builder import HEADS, build_loss
 from .base_head import BaseHead
 
@@ -9,35 +8,20 @@ class ClsHead(BaseHead):
 
     Args:
         loss (dict): Config of classification loss.
-        topk (int | tuple): Top-k accuracy.
     """  # noqa: W605
 
-    def __init__(self,
-                 loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
-                 topk=(1, )):
+    def __init__(self, loss=dict(type='CrossEntropyLoss', loss_weight=1.0)):
         super(ClsHead, self).__init__()
 
         assert isinstance(loss, dict)
-        assert isinstance(topk, (int, tuple))
-        if isinstance(topk, int):
-            topk = (topk, )
-        for _topk in topk:
-            assert _topk > 0, 'Top-k should be larger than 0'
-        self.topk = topk
-
         self.compute_loss = build_loss(loss)
-        self.compute_accuracy = Accuracy(topk=self.topk)
 
     def loss(self, cls_score, gt_label):
         num_samples = len(cls_score)
         losses = dict()
         # compute loss
         loss = self.compute_loss(cls_score, gt_label, avg_factor=num_samples)
-        # compute accuracy
-        acc = self.compute_accuracy(cls_score, gt_label)
-        assert len(acc) == len(self.topk)
         losses['loss'] = loss
-        losses['accuracy'] = {f'top-{k}': a for k, a in zip(self.topk, acc)}
         return losses
 
     def forward_train(self, cls_score, gt_label):

--- a/mmcls/models/heads/linear_head.py
+++ b/mmcls/models/heads/linear_head.py
@@ -21,9 +21,8 @@ class LinearClsHead(ClsHead):
     def __init__(self,
                  num_classes,
                  in_channels,
-                 loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
-                 topk=(1, )):
-        super(LinearClsHead, self).__init__(loss=loss, topk=topk)
+                 loss=dict(type='CrossEntropyLoss', loss_weight=1.0)):
+        super(LinearClsHead, self).__init__(loss=loss)
         self.in_channels = in_channels
         self.num_classes = num_classes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools
 known_first_party = mmcls
-known_third_party = PIL,cv2,mmcv,numpy,pytest,torch,torchvision
+known_third_party = PIL,cv2,mmcv,numpy,onnxruntime,pytest,torch,torchvision
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY


### PR DESCRIPTION
Since metric logic has been moved to dataset.evaluate, the computation of accuracy in the train forward pass is no longer needed.train