### PR TITLE
Update accuracy.py to solve RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead

### DIFF
--- a/mmcls/models/losses/accuracy.py
+++ b/mmcls/models/losses/accuracy.py
@@ -25,7 +25,7 @@ def accuracy_torch(pred, target, topk=1):
     correct = pred_label.eq(target.view(1, -1).expand_as(pred_label))
 
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+        correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
         res.append(correct_k.mul_(100. / num))
     return res
 


### PR DESCRIPTION
Had this error while training "RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead" and solved by changing view(-1) to reshape(-1) in accuracy.py

Some people got same error in here:
https://github.com/open-mmlab/mmdetection/issues/3047