### PR TITLE
Add evaluation metrics for multilabel task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,6 @@ jobs:
         if: ${{matrix.torchvision < 0.5}}
       - name: Install PyTorch
         run: pip install --use-deprecated=legacy-resolver torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
-      # temporary solution until new version of mmcv is avaliable
-      - name: Install pytest
-        run: |
-          pip install pytest
       - name: Install MMCV
         run: |
           pip install --use-deprecated=legacy-resolver mmcv-full==latest+torch${{matrix.torch}} -f https://download.openmmlab.com/mmcv/dist/index.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,10 @@ jobs:
         if: ${{matrix.torchvision < 0.5}}
       - name: Install PyTorch
         run: pip install --use-deprecated=legacy-resolver torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+      # temporary solution until new version of mmcv is avaliable
+      - name: Install pytest
+        run: |
+          pip install pytest
       - name: Install MMCV
         run: |
           pip install --use-deprecated=legacy-resolver mmcv-full==latest+torch${{matrix.torch}} -f https://download.openmmlab.com/mmcv/dist/index.html

--- a/mmcls/core/evaluation/__init__.py
+++ b/mmcls/core/evaluation/__init__.py
@@ -1,3 +1,4 @@
 from .eval_hooks import DistEvalHook, EvalHook
+from .mean_ap import average_precision, mAP
 
-__all__ = ['DistEvalHook', 'EvalHook']
+__all__ = ['DistEvalHook', 'EvalHook', 'average_precision', 'mAP']

--- a/mmcls/core/evaluation/__init__.py
+++ b/mmcls/core/evaluation/__init__.py
@@ -1,4 +1,8 @@
 from .eval_hooks import DistEvalHook, EvalHook
 from .mean_ap import average_precision, mAP
+from .multilabel_eval_metrics import average_performance
 
-__all__ = ['DistEvalHook', 'EvalHook', 'average_precision', 'mAP']
+__all__ = [
+    'DistEvalHook', 'EvalHook', 'average_precision', 'mAP',
+    'average_performance'
+]

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -38,9 +38,13 @@ def mAP(pred, target, difficult_examples=True):
 
     Args:
         pred (torch.Tensor | np.ndarray): The model prediction.
-        target (torch.Tensor | np.ndarray): The target of each prediction, in
-            which -1 stands for negative examples, 0 stands for difficult
-            examples and 1 stand for positive examples.
+        target (torch.Tensor | np.ndarray): The target of each prediction. If
+            difficult_examples is set as True, 1 stands for positive examples,
+            0 stands for difficult examples and -1 stands for negative
+            examples. Otherwise, 1 stands for positive examples and 0 stands
+            for negative examples.
+        difficult_examples (bool): Whether dataset contains difficult_examples.
+            Defaults to True.
 
     Returns:
         float: A single float as mAP value.

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -3,7 +3,9 @@ import torch
 
 
 def average_precision(pred, target):
-    """ Calculate the average precision for a single class
+    r""" Calculate the average precision for a single class, following the
+    convention in `Asymmetric Loss For Multi-Label Classification
+    <https://arxiv.org/abs/2009.14119>`_.
 
     AP summarizes a precision-recall curve as the weighted mean of maximum
     precisions obtained for any r'>r, where r is the recall:

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -6,8 +6,10 @@ def average_precision(pred, target):
     """ Calculate the average precision for a single class
 
     Args:
-        pred (np.ndarray): The model prediction.
-        target (np.ndarray): The target of each prediction.
+        pred (np.ndarray): The model prediction with shape (N, C), where C is
+            the number of classes.
+        target (np.ndarray): The target of each prediction with shape (N, C),
+            where C is the number of classes.
 
     Returns:
         float: a single float as average precision value.
@@ -24,7 +26,7 @@ def average_precision(pred, target):
     total_p = tp[-1]
 
     # count not difficult examples
-    pn_inds = sort_target != 0
+    pn_inds = sort_target != -1
     pn = np.cumsum(pn_inds)
 
     tp[np.logical_not(p_inds)] = 0
@@ -33,18 +35,16 @@ def average_precision(pred, target):
     return ap
 
 
-def mAP(pred, target, difficult_examples=True):
+def mAP(pred, target):
     """ Calculate the mean average precision with respect of classes
 
     Args:
-        pred (torch.Tensor | np.ndarray): The model prediction.
-        target (torch.Tensor | np.ndarray): The target of each prediction. If
-            difficult_examples is set as True, 1 stands for positive examples,
-            0 stands for difficult examples and -1 stands for negative
-            examples. Otherwise, 1 stands for positive examples and 0 stands
-            for negative examples.
-        difficult_examples (bool): Whether dataset contains difficult_examples.
-            Defaults to True.
+        pred (torch.Tensor | np.ndarray): The model prediction with shape
+            (N, C), where C is the number of classes.
+        target (torch.Tensor | np.ndarray): The target of each prediction with
+            shape (N, C), where C is the number of classes. 1 stands for
+            positive examples, 0 stands for negative examples and -1 stands for
+            difficult examples.
 
     Returns:
         float: A single float as mAP value.
@@ -58,8 +58,6 @@ def mAP(pred, target, difficult_examples=True):
 
     assert pred.shape == target.shape
     num_classes = pred.shape[1]
-    if not difficult_examples:
-        target[target == 0] = -1
     ap = np.zeros(num_classes)
     for k in range(num_classes):
         ap[k] = average_precision(pred[:, k], target[:, k])

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -1,0 +1,61 @@
+import numpy as np
+import torch
+
+
+def average_precision(pred, target):
+    """ Calculate the average precision for a single class
+
+    Args:
+        pred (np.ndarray): The model prediction.
+        target (np.ndarray): The target of each prediction.
+
+    Returns:
+        float: a single float as average precision value.
+    """
+    eps = np.finfo(np.float32).eps
+
+    # sort examples
+    sort_inds = np.argsort(-pred)
+    sort_target = target[sort_inds]
+
+    # count true positive examples
+    p_inds = sort_target == 1
+    tp = np.cumsum(p_inds)
+    total_p = tp[-1]
+
+    # count not difficult examples
+    pn_inds = sort_target != 0
+    pn = np.cumsum(pn_inds)
+
+    tp[np.logical_not(p_inds)] = 0
+    precision = tp / (pn + eps)
+    ap = np.sum(precision) / (total_p + eps)
+    return ap
+
+
+def mAP(pred, target):
+    """ Calculate the mean average precision with respect of classes
+
+    Args:
+        pred (torch.Tensor | np.ndarray): The model prediction.
+        target (torch.Tensor | np.ndarray): The target of each prediction, in
+            which -1 stands for negative examples, 0 stands for difficult
+            examples and 1 stand for positive examples.
+
+    Returns:
+        float: A single float as mAP value.
+    """
+    if isinstance(pred, torch.Tensor) and isinstance(target, torch.Tensor):
+        pred = pred.numpy()
+        target = target.numpy()
+    elif not (isinstance(pred, np.ndarray) and isinstance(target, np.ndarray)):
+        raise TypeError('pred and target should both be torch.Tensor or'
+                        'np.ndarray')
+
+    assert pred.shape == target.shape
+    num_labels = pred.shape[1]
+    ap = np.zeros(num_labels)
+    for k in range(num_labels):
+        ap[k] = average_precision(pred[:, k], target[:, k])
+    mean_ap = ap.mean() * 100.0
+    return mean_ap

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -63,6 +63,7 @@ def mAP(pred, target):
         raise TypeError('pred and target should both be torch.Tensor or'
                         'np.ndarray')
 
+    # pred and target should be in the same shape
     assert pred.shape == target.shape
     num_classes = pred.shape[1]
     ap = np.zeros(num_classes)

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -5,6 +5,15 @@ import torch
 def average_precision(pred, target):
     """ Calculate the average precision for a single class
 
+    AP summarizes a precision-recall curve as the weighted mean of maximum
+    precisions obtained for any r'>r, where r is the recall:
+
+    ..math::
+        \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
+
+    Note that no approximation is involved since the curve is piecewise
+    constant.
+
     Args:
         pred (np.ndarray): The model prediction with shape (N, ).
         target (np.ndarray): The target of each prediction with shape (N, ).
@@ -19,17 +28,17 @@ def average_precision(pred, target):
     sort_target = target[sort_inds]
 
     # count true positive examples
-    p_inds = sort_target == 1
-    tp = np.cumsum(p_inds)
-    total_p = tp[-1]
+    pos_inds = sort_target == 1
+    tp = np.cumsum(pos_inds)
+    total_pos = tp[-1]
 
     # count not difficult examples
     pn_inds = sort_target != -1
     pn = np.cumsum(pn_inds)
 
-    tp[np.logical_not(p_inds)] = 0
+    tp[np.logical_not(pos_inds)] = 0
     precision = tp / np.maximum(pn, eps)
-    ap = np.sum(precision) / np.maximum(total_p, eps)
+    ap = np.sum(precision) / np.maximum(total_pos, eps)
     return ap
 
 

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -63,8 +63,8 @@ def mAP(pred, target):
         raise TypeError('pred and target should both be torch.Tensor or'
                         'np.ndarray')
 
-    # pred and target should be in the same shape
-    assert pred.shape == target.shape
+    assert pred.shape == \
+        target.shape, 'pred and target should be in the same shape.'
     num_classes = pred.shape[1]
     ap = np.zeros(num_classes)
     for k in range(num_classes):

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -6,10 +6,8 @@ def average_precision(pred, target):
     """ Calculate the average precision for a single class
 
     Args:
-        pred (np.ndarray): The model prediction with shape (N, C), where C is
-            the number of classes.
-        target (np.ndarray): The target of each prediction with shape (N, C),
-            where C is the number of classes.
+        pred (np.ndarray): The model prediction with shape (N, ).
+        target (np.ndarray): The target of each prediction with shape (N, ).
 
     Returns:
         float: a single float as average precision value.
@@ -30,8 +28,8 @@ def average_precision(pred, target):
     pn = np.cumsum(pn_inds)
 
     tp[np.logical_not(p_inds)] = 0
-    precision = tp / (pn + eps)
-    ap = np.sum(precision) / (total_p + eps)
+    precision = tp / np.maximum(pn, eps)
+    ap = np.sum(precision) / np.maximum(total_p, eps)
     return ap
 
 

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -3,9 +3,7 @@ import torch
 
 
 def average_precision(pred, target):
-    r""" Calculate the average precision for a single class, following the
-    convention in `Asymmetric Loss For Multi-Label Classification
-    <https://arxiv.org/abs/2009.14119>`_.
+    """ Calculate the average precision for a single class
 
     AP summarizes a precision-recall curve as the weighted mean of maximum
     precisions obtained for any r'>r, where r is the recall:

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -7,15 +7,6 @@ def average_precision(pred, target):
     convention in `Asymmetric Loss For Multi-Label Classification
     <https://arxiv.org/abs/2009.14119>`_.
 
-    AP summarizes a precision-recall curve as the weighted mean of maximum
-    precisions obtained for any r'>r, where r is the recall:
-
-    ..math::
-        \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
-
-    Note that no approximation is involved since the curve is piecewise
-    constant.
-
     Args:
         pred (np.ndarray): The model prediction with shape (N, ).
         target (np.ndarray): The target of each prediction with shape (N, ).
@@ -30,17 +21,17 @@ def average_precision(pred, target):
     sort_target = target[sort_inds]
 
     # count true positive examples
-    pos_inds = sort_target == 1
-    tp = np.cumsum(pos_inds)
-    total_pos = tp[-1]
+    p_inds = sort_target == 1
+    tp = np.cumsum(p_inds)
+    total_p = tp[-1]
 
     # count not difficult examples
     pn_inds = sort_target != -1
     pn = np.cumsum(pn_inds)
 
-    tp[np.logical_not(pos_inds)] = 0
+    tp[np.logical_not(p_inds)] = 0
     precision = tp / np.maximum(pn, eps)
-    ap = np.sum(precision) / np.maximum(total_pos, eps)
+    ap = np.sum(precision) / np.maximum(total_p, eps)
     return ap
 
 

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -7,6 +7,15 @@ def average_precision(pred, target):
     convention in `Asymmetric Loss For Multi-Label Classification
     <https://arxiv.org/abs/2009.14119>`_.
 
+    AP summarizes a precision-recall curve as the weighted mean of maximum
+    precisions obtained for any r'>r, where r is the recall:
+
+    ..math::
+        \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
+
+    Note that no approximation is involved since the curve is piecewise
+    constant.
+
     Args:
         pred (np.ndarray): The model prediction with shape (N, ).
         target (np.ndarray): The target of each prediction with shape (N, ).
@@ -21,17 +30,17 @@ def average_precision(pred, target):
     sort_target = target[sort_inds]
 
     # count true positive examples
-    p_inds = sort_target == 1
-    tp = np.cumsum(p_inds)
-    total_p = tp[-1]
+    pos_inds = sort_target == 1
+    tp = np.cumsum(pos_inds)
+    total_pos = tp[-1]
 
     # count not difficult examples
     pn_inds = sort_target != -1
     pn = np.cumsum(pn_inds)
 
-    tp[np.logical_not(p_inds)] = 0
+    tp[np.logical_not(pos_inds)] = 0
     precision = tp / np.maximum(pn, eps)
-    ap = np.sum(precision) / np.maximum(total_p, eps)
+    ap = np.sum(precision) / np.maximum(total_pos, eps)
     return ap
 
 

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -33,7 +33,7 @@ def average_precision(pred, target):
     return ap
 
 
-def mAP(pred, target):
+def mAP(pred, target, difficult_examples=True):
     """ Calculate the mean average precision with respect of classes
 
     Args:
@@ -53,9 +53,11 @@ def mAP(pred, target):
                         'np.ndarray')
 
     assert pred.shape == target.shape
-    num_labels = pred.shape[1]
-    ap = np.zeros(num_labels)
-    for k in range(num_labels):
+    num_classes = pred.shape[1]
+    if not difficult_examples:
+        target[target == 0] = -1
+    ap = np.zeros(num_classes)
+    for k in range(num_classes):
         ap[k] = average_precision(pred[:, k], target[:, k])
     mean_ap = ap.mean() * 100.0
     return mean_ap

--- a/mmcls/core/evaluation/multilabel_eval_metrics.py
+++ b/mmcls/core/evaluation/multilabel_eval_metrics.py
@@ -43,19 +43,19 @@ def average_performance(pred, target, thr=None, k=None):
     target[target == -1] = 0
     if thr is not None:
         # a label is predicted positive if the confidence is no lower than thr
-        p_inds = pred >= thr
+        pos_inds = pred >= thr
 
     else:
         # top-k labels will be predicted positive for any example
         sort_inds = np.argsort(-pred, axis=1)
         sort_inds_ = sort_inds[:, :k]
         inds = np.indices(sort_inds_.shape)
-        p_inds = np.zeros_like(pred)
-        p_inds[inds[0], sort_inds_] = 1
+        pos_inds = np.zeros_like(pred)
+        pos_inds[inds[0], sort_inds_] = 1
 
-    tp = (p_inds * target) == 1
-    fp = (p_inds * (1 - target)) == 1
-    fn = ((1 - p_inds) * target) == 1
+    tp = (pos_inds * target) == 1
+    fp = (pos_inds * (1 - target)) == 1
+    fn = ((1 - pos_inds) * target) == 1
 
     precision_class = tp.sum(axis=0) / np.maximum(
         tp.sum(axis=0) + fp.sum(axis=0), eps)

--- a/mmcls/core/evaluation/multilabel_eval_metrics.py
+++ b/mmcls/core/evaluation/multilabel_eval_metrics.py
@@ -10,10 +10,12 @@ def average_performance(pred, target, thrs=None, k=None):
         stands for recall and F1 stands for F1-score
 
     Args:
-        pred (torch.Tensor | np.ndarray): The model prediction.
-        target (torch.Tensor | np.ndarray): The target of each prediction, in
-            which 1 stands for positive examples and both -1 and 0 stand for
-            negative examples.
+        pred (torch.Tensor | np.ndarray): The model prediction with shape
+            (N, C), where C is the number of classes.
+        target (torch.Tensor | np.ndarray): The target of each prediction with
+            shape (N, C), where C is the number of classes. 1 stands for
+            positive examples, 0 stands for negative examples and -1 stands for
+            difficult examples.
         thrs (float): The confidence threshold. Defaults to None.
         k (int): Top-k performance. Note that if thrs and k are both given, k
             will be ignored. Defaults to None.

--- a/mmcls/core/evaluation/multilabel_eval_metrics.py
+++ b/mmcls/core/evaluation/multilabel_eval_metrics.py
@@ -37,6 +37,7 @@ def average_performance(pred, target, thr=None, k=None):
         warnings.warn('Both thr and k are given, use threshold in favor of '
                       'top-k.')
 
+    # pred and target should be in the same shape
     assert pred.shape == target.shape
 
     eps = np.finfo(np.float32).eps

--- a/mmcls/core/evaluation/multilabel_eval_metrics.py
+++ b/mmcls/core/evaluation/multilabel_eval_metrics.py
@@ -16,31 +16,31 @@ def average_performance(pred, target, thrs=None, k=None):
             negative examples.
         thrs (float): The confidence threshold. Defaults to None.
         k (int): Top-k performance. Note that if thrs and k are both given, k
-            will be ignored if thrs is given. Defaults to None.
+            will be ignored. Defaults to None.
 
     Returns:
         tuple: (CP, CR, CF1, OP, OR, OF1)
     """
-    if thrs is None and k is None:
-        thrs = 0.5
-        warnings.warn('Neither thrs and k is given, set thrs as 0.5 by '
-                      'default.')
-    elif thrs is not None and k is not None:
-        warnings.warn('Both thrs and k are given, use threshold in favor of '
-                      'top-k')
     if isinstance(pred, torch.Tensor) and isinstance(target, torch.Tensor):
         pred = pred.numpy()
         target = target.numpy()
     elif not (isinstance(pred, np.ndarray) and isinstance(target, np.ndarray)):
         raise TypeError('pred and target should both be torch.Tensor or'
                         'np.ndarray')
+    if thrs is None and k is None:
+        thrs = 0.5
+        warnings.warn('Neither thrs nor k is given, set thrs as 0.5 by '
+                      'default.')
+    elif thrs is not None and k is not None:
+        warnings.warn('Both thrs and k are given, use threshold in favor of '
+                      'top-k.')
 
     assert pred.shape == target.shape
 
     eps = np.finfo(np.float32).eps
     target[target == -1] = 0
     if thrs is not None:
-        # a label is predicted positive if the cofidence if greater than thrs
+        # a label is predicted positive if the confidence is no lower than thrs
         p_inds = pred >= thrs
 
     else:

--- a/mmcls/core/evaluation/multilabel_eval_metrics.py
+++ b/mmcls/core/evaluation/multilabel_eval_metrics.py
@@ -37,8 +37,8 @@ def average_performance(pred, target, thr=None, k=None):
         warnings.warn('Both thr and k are given, use threshold in favor of '
                       'top-k.')
 
-    # pred and target should be in the same shape
-    assert pred.shape == target.shape
+    assert pred.shape == \
+        target.shape, 'pred and target should be in the same shape.'
 
     eps = np.finfo(np.float32).eps
     target[target == -1] = 0

--- a/mmcls/core/evaluation/multilabel_eval_metrics.py
+++ b/mmcls/core/evaluation/multilabel_eval_metrics.py
@@ -1,0 +1,66 @@
+import warnings
+
+import numpy as np
+import torch
+
+
+def average_performance(pred, target, thrs=None, k=None):
+    """Calculate CP, CR, CF1, OP, OR, OF1, where C stands for per-class
+        average, O stands for overall average, P stands for precision, R
+        stands for recall and F1 stands for F1-score
+
+    Args:
+        pred (torch.Tensor | np.ndarray): The model prediction.
+        target (torch.Tensor | np.ndarray): The target of each prediction, in
+            which 1 stands for positive examples and both -1 and 0 stand for
+            negative examples.
+        thrs (float): The confidence threshold. Defaults to None.
+        k (int): Top-k performance. Note that if thrs and k are both given, k
+            will be ignored if thrs is given. Defaults to None.
+
+    Returns:
+        tuple: (CP, CR, CF1, OP, OR, OF1)
+    """
+    if thrs is None and k is None:
+        thrs = 0.5
+        warnings.warn('Neither thrs and k is given, set thrs as 0.5 by '
+                      'default.')
+    elif thrs is not None and k is not None:
+        warnings.warn('Both thrs and k are given, use threshold in favor of '
+                      'top-k')
+    if isinstance(pred, torch.Tensor) and isinstance(target, torch.Tensor):
+        pred = pred.numpy()
+        target = target.numpy()
+    elif not (isinstance(pred, np.ndarray) and isinstance(target, np.ndarray)):
+        raise TypeError('pred and target should both be torch.Tensor or'
+                        'np.ndarray')
+
+    assert pred.shape == target.shape
+
+    eps = np.finfo(np.float32).eps
+    target[target == -1] = 0
+    if thrs is not None:
+        # a label is predicted positive if the cofidence if greater than thrs
+        p_inds = pred >= thrs
+
+    else:
+        # top-k labels will be predicted positive for any example
+        sort_inds = np.argsort(-pred, axis=1)
+        sort_inds_ = sort_inds[:, :k]
+        inds = np.indices(sort_inds_.shape)
+        p_inds = np.zeros_like(pred)
+        p_inds[inds[0], sort_inds_] = 1
+
+    tp = (p_inds * target) == 1
+    fp = (p_inds * (1 - target)) == 1
+    fn = ((1 - p_inds) * target) == 1
+
+    precision_class = tp.sum(0) / (tp.sum(0) + fp.sum(0) + eps)
+    recall_class = tp.sum(0) / (tp.sum(0) + fn.sum(0) + eps)
+    CP = precision_class.mean() * 100.0
+    CR = recall_class.mean() * 100.0
+    CF1 = 2 * CP * CR / (CP + CR + eps)
+    OP = tp.sum() / (tp.sum() + fp.sum() + eps) * 100.0
+    OR = tp.sum() / (tp.sum() + fn.sum() + eps) * 100.0
+    OF1 = 2 * OP * OR / (OP + OR + eps)
+    return CP, CR, CF1, OP, OR, OF1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,8 +5,8 @@ from mmcls.core import mAP
 
 
 def test_mAP():
-    target = torch.Tensor([[1, 1, -1, 0], [-1, 1, -1, 0], [-1, 0, 1, 0],
-                           [1, -1, -1, 0]])
+    target = torch.Tensor([[1, 1, -1, 0], [1, 1, -1, 0], [-1, 0, 1, 0],
+                           [-1, 1, -1, 0]])
     pred = torch.Tensor([[0.9, 0.8, 0.3, 0.2], [0.1, 0.2, 0.2, 0.1],
                          [0.7, 0.5, 0.9, 0.3], [0.8, 0.1, 0.1, 0.2]])
 
@@ -20,4 +20,13 @@ def test_mAP():
         target_shorter = target[:-1]
         _ = mAP(pred, target_shorter)
 
-    assert mAP(pred, target) == pytest.approx(74.99999)
+    assert mAP(pred, target) == pytest.approx(68.75, rel=1e-2)
+
+    target_no_difficult = torch.Tensor([[1, 1, 0, 0], [0, 1, 0, 0],
+                                        [0, 0, 1, 0], [1, 0, 0, 0]])
+    target_with_difficult = torch.Tensor([[1, 1, -1, -1], [-1, 1, -1, -1],
+                                          [-1, -1, 1, -1], [1, -1, -1, -1]])
+    assert mAP(pred, target_no_difficult, difficult_examples=False) \
+        == mAP(pred, target_with_difficult)
+    assert mAP(pred, target_no_difficult, difficult_examples=False) \
+        == pytest.approx(70.83, rel=1e-2)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+
+from mmcls.core import mAP
+
+
+def test_mAP():
+    target = torch.Tensor([[1, 1, -1, 0], [-1, 1, -1, 0], [-1, 0, 1, 0],
+                           [1, -1, -1, 0]])
+    pred = torch.Tensor([[0.9, 0.8, 0.3, 0.2], [0.1, 0.2, 0.2, 0.1],
+                         [0.7, 0.5, 0.9, 0.3], [0.8, 0.1, 0.1, 0.2]])
+
+    # target and pred should both be np.ndarray or torch.Tensor
+    with pytest.raises(TypeError):
+        target_list = target.tolist()
+        _ = mAP(pred, target_list)
+
+    # target and pred should be in the same shape
+    with pytest.raises(AssertionError):
+        target_shorter = target[:-1]
+        _ = mAP(pred, target_shorter)
+
+    assert mAP(pred, target) == pytest.approx(74.99999)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from mmcls.core import mAP
+from mmcls.core import average_performance, mAP
 
 
 def test_mAP():
@@ -30,3 +30,32 @@ def test_mAP():
         == mAP(pred, target_with_difficult)
     assert mAP(pred, target_no_difficult, difficult_examples=False) \
         == pytest.approx(70.83, rel=1e-2)
+
+
+def test_average_performance():
+    pred = torch.Tensor([[0.9, 0.8, 0.3, 0.2], [0.1, 0.2, 0.2, 0.1],
+                         [0.7, 0.5, 0.9, 0.3], [0.8, 0.1, 0.1, 0.2],
+                         [0.8, 0.1, 0.1, 0.2]])
+    target = torch.Tensor([[1, 1, -1, 0], [1, 1, -1, 0], [-1, 0, 1, 0],
+                           [-1, 1, -1, 0], [-1, 1, -1, 0]])
+
+    # target and pred should both be np.ndarray or torch.Tensor
+    with pytest.raises(TypeError):
+        target_list = target.tolist()
+        _ = average_performance(pred, target_list)
+
+    # target and pred should be in the same shape
+    with pytest.raises(AssertionError):
+        target_shorter = target[:-1]
+        _ = average_performance(pred, target_shorter)
+
+    assert average_performance(pred, target) == average_performance(
+        pred, target, thrs=0.5)
+    assert average_performance(pred, target, thrs=0.5, k=2) \
+        == average_performance(pred, target, thrs=0.5)
+    assert average_performance(
+        pred, target, thrs=0.3) == pytest.approx(
+            (31.25, 43.75, 36.46, 33.33, 42.86, 37.50), rel=1e-2)
+    assert average_performance(
+        pred, target, k=2) == pytest.approx(
+            (43.75, 50.00, 46.67, 40.00, 57.14, 47.06), rel=1e-2)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,8 +5,8 @@ from mmcls.core import average_performance, mAP
 
 
 def test_mAP():
-    target = torch.Tensor([[1, 1, -1, 0], [1, 1, -1, 0], [-1, 0, 1, 0],
-                           [-1, 1, -1, 0]])
+    target = torch.Tensor([[1, 1, 0, -1], [1, 1, 0, -1], [0, -1, 1, -1],
+                           [0, 1, 0, -1]])
     pred = torch.Tensor([[0.9, 0.8, 0.3, 0.2], [0.1, 0.2, 0.2, 0.1],
                          [0.7, 0.5, 0.9, 0.3], [0.8, 0.1, 0.1, 0.2]])
 
@@ -24,20 +24,15 @@ def test_mAP():
 
     target_no_difficult = torch.Tensor([[1, 1, 0, 0], [0, 1, 0, 0],
                                         [0, 0, 1, 0], [1, 0, 0, 0]])
-    target_with_difficult = torch.Tensor([[1, 1, -1, -1], [-1, 1, -1, -1],
-                                          [-1, -1, 1, -1], [1, -1, -1, -1]])
-    assert mAP(pred, target_no_difficult, difficult_examples=False) \
-        == mAP(pred, target_with_difficult)
-    assert mAP(pred, target_no_difficult, difficult_examples=False) \
-        == pytest.approx(70.83, rel=1e-2)
+    assert mAP(pred, target_no_difficult) == pytest.approx(70.83, rel=1e-2)
 
 
 def test_average_performance():
+    target = torch.Tensor([[1, 1, 0, -1], [1, 1, 0, -1], [0, -1, 1, -1],
+                           [0, 1, 0, -1], [0, 1, 0, -1]])
     pred = torch.Tensor([[0.9, 0.8, 0.3, 0.2], [0.1, 0.2, 0.2, 0.1],
                          [0.7, 0.5, 0.9, 0.3], [0.8, 0.1, 0.1, 0.2],
                          [0.8, 0.1, 0.1, 0.2]])
-    target = torch.Tensor([[1, 1, -1, 0], [1, 1, -1, 0], [-1, 0, 1, 0],
-                           [-1, 1, -1, 0], [-1, 1, -1, 0]])
 
     # target and pred should both be np.ndarray or torch.Tensor
     with pytest.raises(TypeError):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -45,11 +45,11 @@ def test_average_performance():
         _ = average_performance(pred, target_shorter)
 
     assert average_performance(pred, target) == average_performance(
-        pred, target, thrs=0.5)
-    assert average_performance(pred, target, thrs=0.5, k=2) \
-        == average_performance(pred, target, thrs=0.5)
+        pred, target, thr=0.5)
+    assert average_performance(pred, target, thr=0.5, k=2) \
+        == average_performance(pred, target, thr=0.5)
     assert average_performance(
-        pred, target, thrs=0.3) == pytest.approx(
+        pred, target, thr=0.3) == pytest.approx(
             (31.25, 43.75, 36.46, 33.33, 42.86, 37.50), rel=1e-2)
     assert average_performance(
         pred, target, k=2) == pytest.approx(


### PR DESCRIPTION
Add mAP, CP, CR, CF1, OP, OR, OF1 as multi-label task evaluation metrics:
1. Unittests are put in multilabel_eval_metrics.py temporarily, and I will put them in test_dataset.py once multi-label datasets are ready.
2. In papers, some report topk performance while others use threshold, so both methods are implemented for future convenience.
3. For mAP, the method provided by PASCAL VOC after 2010 is used.