### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,4 @@ repos:
     rev: 2.1.4
     hooks:
       - id: markdownlint
-        args: ["-r", "~MD002,~MD013,~MD029,~MD033,~MD034,~MD036"]
+        args: ["-r", "~MD002,~MD013,~MD024,~MD029,~MD033,~MD034,~MD036"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Documentation: https://mmclassification.readthedocs.io/en/latest/
 
 This project is released under the [Apache 2.0 license](LICENSE).
 
+## Changelog
+
+v0.7.0 was released in 31/12/2020.
+Please refer to [changelog.md](docs/changelog.md) for details and release history.
+
 ## Benchmark and model zoo
 
 Results and models are available in the [model zoo](docs/model_zoo.md).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,13 +8,13 @@
 #### New Features
 
 - Remove installation of MMCV from requirements. (#90)
-- Add more evaluation metrics: precision, recall and F-1 score. (#93)
-- Allow overriding configs through input argument when testing and inferencing. (#91 & #96)
+- Add 3 evaluation metrics: precision, recall and F-1 score. (#93)
+- Allow config override during testing and inference with `--options`. (#91 & #96)
 
 #### Bug Fixes
 
-- Add `CLASSES` in dataset wrappers. (#66)
-- Fix `round_up` parameter in evaluation during training. (#69)
+- Add missing `CLASSES` argument to dataset wrappers. (#66)
+- Fix slurm evaluation error during training. (#69)
 - Resolve error caused by shape in `Accuracy`. (#104)
 - Fix bug caused by extremely insufficient data in distributed sampler.(#108)
 - Fix bug in `gpu_ids` in distributed training. (#107)
@@ -22,10 +22,10 @@
 
 #### Improvements
 
-- Use `build runner` to enable more flexible use of runners. (#54)
-- Support get category id method in `BaseDataset`. (#72)
-- Allow overriding `CLASSES` when initializing `BaseDataset`. (#85)
-- Allow input image as ndarray when inferencing. (#87)
+- Use `build_runner` to make runners more flexible. (#54)
+- Support to get category ids in `BaseDataset`. (#72)
+- Allow `CLASSES` override during `BaseDateset` initialization. (#85)
+- Allow input image as ndarray during inference. (#87)
 - Optimize MNIST config. (#98)
 - Add config links in model zoo documentation. (#99)
 - Use functions from MMCV to collect environment. (#103)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,68 @@
+## Changelog
+
+### v0.7.0(31/12/2020)
+
+- Add more evaluation metrics
+- Fix bugs
+
+#### New Features
+
+- Remove installation of MMCV from requirements. (#90)
+- Add more evaluation metrics: precision, recall and F-1 score. (#93)
+- Allow overriding configs through input argument when testing and inferencing. (#91 & #96)
+
+#### Bug Fixes
+
+- Add `CLASSES` in dataset wrappers. (#66)
+- Fix `round_up` parameter in evaluation during training. (#69)
+- Resolve error caused by shape in `Accuracy`. (#104)
+- Fix bug caused by extremely insufficient data in distributed sampler.(#108)
+- Fix bug in `gpu_ids` in distributed training. (#107)
+- Fix bug caused by extremely insufficient data in collect results during testing (#114)
+
+#### Improvements
+
+- Use `build runner` to enable more flexible use of runners. (#54)
+- Support get category id method in `BaseDataset`. (#72)
+- Allow overriding `CLASSES` when initializing `BaseDataset`. (#85)
+- Allow input image as ndarray when inferencing. (#87)
+- Optimize MNIST config. (#98)
+- Add config links in model zoo documentation. (#99)
+- Use functions from MMCV to collect environment. (#103)
+- Refactor config files so that they are now categorized by methods. (#116)
+- Add README in config directory. (#117)
+- Add model statistics. (#119)
+- Refactor documentation in consistency with other MM repositories. (#126)
+
+### v0.6.0(11/10/2020)
+
+- Support new method: ResNeSt and VGG.
+- Support new dataset: CIFAR10.
+- Provide new tools to do model inference, model conversion from pytorch to onnx.
+
+#### New Features
+
+- Add model inference. (#16)
+- Add pytorch2onnx. (#20)
+- Add PIL backend for transform `Resize`. (#21)
+- Add ResNeSt. (#25)
+- Add VGG and its pretained models. (#27)
+- Add CIFAR10 configs and models. (#38)
+- Add albumentations transforms. (#45)
+- Visualize results on image demo. (#58)
+
+#### Bug Fixes
+
+- Fix init_weights in `shufflenet_v2.py`. (#29)
+- Fix the parameter `size` in test_pipeline. (#30)
+- Fix the parameter in cosine lr schedule. (#32)
+- Fix the convert tools for mobilenet_v2. (#34)
+- Fix crash in CenterCrop transform when image is greyscale (#40)
+- Fix outdated configs. (#53)
+
+#### Improvements
+
+- Replace urlretrieve with urlopen in dataset.utils. (#13)
+- Resize image according to its short edge. (#22)
+- Update ShuffleNet config. (#31)
+- Update pre-trained models for shufflenet_v2, shufflenet_v1, se-resnet50, se-resnet101. (#33)

--- a/mmcls/version.py
+++ b/mmcls/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 
 
 def parse_version_info(version_str):


### PR DESCRIPTION
Hi,
Please kindly have a look at the following notes:
I assume the new version date is 2020.12.31? Pls correct me if I was wrong.
#112, #122 are not included since they fix bugs of evaluation metrics which is also released in this version.
#90 is included, but I am not quite sure whether it is appropriate. Should we instruct users on how to install mmcv in docs somewhere?
#102, #106, #115, #118 are not included since I assume replacing urls in model zoo, pre-commit hook, ci and links in docs should not be much of users' concerns?

And I disabled MD024 since it conflicts our current changelog style. I already checked other repos and made sure they have done the same. 