### PR TITLE
[Feature] Support PASCAL VOC 2007 dataset for multilabel task

### DIFF
--- a/mmcls/datasets/__init__.py
+++ b/mmcls/datasets/__init__.py
@@ -5,11 +5,13 @@ from .dataset_wrappers import (ClassBalancedDataset, ConcatDataset,
                                RepeatDataset)
 from .imagenet import ImageNet
 from .mnist import MNIST, FashionMNIST
+from .multi_label import MultiLabelDataset
 from .samplers import DistributedSampler
+from .voc import VOC
 
 __all__ = [
     'BaseDataset', 'ImageNet', 'CIFAR10', 'CIFAR100', 'MNIST', 'FashionMNIST',
-    'build_dataloader', 'build_dataset', 'Compose', 'DistributedSampler',
-    'ConcatDataset', 'RepeatDataset', 'ClassBalancedDataset', 'DATASETS',
-    'PIPELINES'
+    'VOC', 'MultiLabelDataset', 'build_dataloader', 'build_dataset', 'Compose',
+    'DistributedSampler', 'ConcatDataset', 'RepeatDataset',
+    'ClassBalancedDataset', 'DATASETS', 'PIPELINES'
 ]

--- a/mmcls/datasets/base_dataset.py
+++ b/mmcls/datasets/base_dataset.py
@@ -36,8 +36,8 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         self.data_prefix = data_prefix
         self.test_mode = test_mode
         self.pipeline = Compose(pipeline)
-        self.data_infos = self.load_annotations()
         self.CLASSES = self.get_classes(classes)
+        self.data_infos = self.load_annotations()
 
     @abstractmethod
     def load_annotations(self):
@@ -133,13 +133,13 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             metrics = metric
         allowed_metrics = ['accuracy', 'precision', 'recall', 'f1_score']
         eval_results = {}
+        results = np.vstack(results)
+        gt_labels = self.get_gt_labels()
+        num_imgs = len(results)
+        assert len(gt_labels) == num_imgs
         for metric in metrics:
             if metric not in allowed_metrics:
                 raise KeyError(f'metric {metric} is not supported.')
-            results = np.vstack(results)
-            gt_labels = self.get_gt_labels()
-            num_imgs = len(results)
-            assert len(gt_labels) == num_imgs
             if metric == 'accuracy':
                 topk = metric_options.get('topk')
                 acc = accuracy(results, gt_labels, topk)

--- a/mmcls/datasets/multi_label.py
+++ b/mmcls/datasets/multi_label.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from mmcls.core import average_performance, mAP
+from .base_dataset import BaseDataset
+
+
+class MultiLabelDataset(BaseDataset):
+    """ Multi-label Dataset.
+    """
+
+    def get_cat_ids(self, idx):
+        """Get category ids by index.
+
+        Args:
+            idx (int): Index of data.
+
+        Returns:
+            int: Image categories of specified index.
+        """
+        gt_labels = self.data_infos[idx]['gt_label']
+        cat_ids = np.where(gt_labels == 1)[0]
+        return cat_ids
+
+    def evaluate(self, results, metric='mAP', logger=None, **eval_kwargs):
+        """Evaluate the dataset.
+
+        Args:
+            results (list): Testing results of the dataset.
+            metric (str | list[str]): Metrics to be evaluated.
+                Default value is 'mAP'. Options are 'mAP', 'CP', 'CR', 'CF1',
+                'OP', 'OR' and 'OF1'.
+            logger (logging.Logger | None | str): Logger used for printing
+                related information during evaluation. Default: None.
+        Returns:
+            dict: evaluation results
+        """
+        if isinstance(metric, str):
+            metrics = [metric]
+        else:
+            metrics = metric
+        allowed_metrics = ['mAP', 'CP', 'CR', 'CF1', 'OP', 'OR', 'OF1']
+        eval_results = {}
+        results = np.vstack(results)
+        gt_labels = self.get_gt_labels()
+        num_imgs = len(results)
+        assert len(gt_labels) == num_imgs, 'dataset testing results should '\
+            'be of the same length as gt_labels.'
+
+        invalid_metrics = set(metrics) - set(allowed_metrics)
+        if len(invalid_metrics) != 0:
+            raise KeyError(f'metirc {invalid_metrics} is not supported.')
+
+        if 'mAP' in metrics:
+            mAP_value = mAP(results, gt_labels)
+            eval_results['mAP'] = mAP_value
+            metrics.remove('mAP')
+        if len(metrics) != 0:
+            performance_keys = ['CP', 'CR', 'CF1', 'OP', 'OR', 'OF1']
+            performance_values = average_performance(results, gt_labels,
+                                                     **eval_kwargs)
+            for k, v in zip(performance_keys, performance_values):
+                if k in metrics:
+                    eval_results[k] = v
+
+        return eval_results

--- a/mmcls/datasets/multi_label.py
+++ b/mmcls/datasets/multi_label.py
@@ -15,7 +15,7 @@ class MultiLabelDataset(BaseDataset):
             idx (int): Index of data.
 
         Returns:
-            int: Image categories of specified index.
+            np.ndarray: Image categories of specified index.
         """
         gt_labels = self.data_infos[idx]['gt_label']
         cat_ids = np.where(gt_labels == 1)[0]

--- a/mmcls/datasets/voc.py
+++ b/mmcls/datasets/voc.py
@@ -39,12 +39,12 @@ class VOC(MultiLabelDataset):
                                 f'{img_id}.xml')
             tree = ET.parse(xml_path)
             root = tree.getroot()
-            # need shape info?
             labels = []
             labels_difficult = []
             for obj in root.findall('object'):
                 label_name = obj.find('name').text
                 # in case customized dataset has wrong labels
+                # or CLASSES has been override.
                 if label_name not in self.CLASSES:
                     continue
                 label = self.class_to_idx[label_name]

--- a/mmcls/datasets/voc.py
+++ b/mmcls/datasets/voc.py
@@ -1,0 +1,69 @@
+import os.path as osp
+import xml.etree.ElementTree as ET
+
+import mmcv
+import numpy as np
+
+from .builder import DATASETS
+from .multi_label import MultiLabelDataset
+
+
+@DATASETS.register_module()
+class VOC(MultiLabelDataset):
+    """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Dataset.
+    """
+
+    CLASSES = ('aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car',
+               'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse',
+               'motorbike', 'person', 'pottedplant', 'sheep', 'sofa', 'train',
+               'tvmonitor')
+
+    def __init__(self, **kwargs):
+        super(VOC, self).__init__(**kwargs)
+        if 'VOC2007' in self.data_prefix:
+            self.year = 2007
+        else:
+            raise ValueError('Cannot infer dataset year from img_prefix.')
+
+    def load_annotations(self):
+        """Load annotations
+
+        Returns:
+            list[dict]: Annotation info from XML file.
+        """
+        data_infos = []
+        img_ids = mmcv.list_from_file(self.ann_file)
+        for img_id in img_ids:
+            filename = f'JPEGImages/{img_id}.jpg'
+            xml_path = osp.join(self.data_prefix, 'Annotations',
+                                f'{img_id}.xml')
+            tree = ET.parse(xml_path)
+            root = tree.getroot()
+            # need shape info?
+            labels = []
+            labels_difficult = []
+            for obj in root.findall('object'):
+                label_name = obj.find('name').text
+                # in case customized dataset has wrong labels
+                if label_name not in self.CLASSES:
+                    continue
+                label = self.class_to_idx[label_name]
+                difficult = int(obj.find('difficult').text)
+                if difficult:
+                    labels_difficult.append(label)
+                else:
+                    labels.append(label)
+
+            gt_label = np.zeros(len(self.CLASSES))
+            # The order cannot be swapped for the case where multiple objects
+            # of the same kind exist and some are difficult.
+            gt_label[labels_difficult] = -1
+            gt_label[labels] = 1
+
+            info = dict(
+                img_prefix=self.data_prefix,
+                img_info=dict(filename=filename),
+                gt_label=gt_label.astype(np.int8))
+            data_infos.append(info)
+
+        return data_infos


### PR DESCRIPTION
Hi,
This pull request supports dataset PASCAL VOC for multi-label task. Currently, only VOC2007 is supported.
Several details:
1. A MultiLabelDataset is implemented for future convenience since we plan to support other multi-label dataset, e.g. COCO. And it is not registered in DATASETS on purpose for it is not a complete dataset and we don't really want users to instantiate it.
2. The data format of gt_labels and cat_ids may vary from those of single-label multi-class task. 
3. Previously I promise to move test_metrics to test_dataset, however, now I doubt if that is a good idea. If I put them together, some parameter validity checks can not be covered. So I suggest that we should leave it as it was.
4. In the case where users only use a subset of VOC classes, a function that filters the images without any valid labels need to be implemented. However, I am not sure if that is our job or we should leave it to users. Please let me know your opinion if possible.
Please kindly take a look and let me know if adjustments are needed. Thx.