### PR TITLE
[Feature] Add --eval-options in test.py

### DIFF
--- a/mmcls/datasets/base_dataset.py
+++ b/mmcls/datasets/base_dataset.py
@@ -115,7 +115,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
     def evaluate(self,
                  results,
                  metric='accuracy',
-                 metric_options={'topk': (1, 5)},
+                 metric_options=None,
                  logger=None):
         """Evaluate the dataset.
 
@@ -130,6 +130,8 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         Returns:
             dict: evaluation results
         """
+        if metric_options is None:
+            metric_options = {'topk': (1, 5)}
         if isinstance(metric, str):
             metrics = [metric]
         else:

--- a/mmcls/datasets/base_dataset.py
+++ b/mmcls/datasets/base_dataset.py
@@ -123,10 +123,11 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
             results (list): Testing results of the dataset.
             metric (str | list[str]): Metrics to be evaluated.
                 Default value is `accuracy`.
-            metric_options (dict): Options for calculating metrics. Allowed
-                keys are 'topk', 'thrs' and 'average_mode'.
-            logger (logging.Logger | None | str): Logger used for printing
-                related information during evaluation. Default: None.
+            metric_options (dict, optional): Options for calculating metrics.
+                Allowed keys are 'topk', 'thrs' and 'average_mode'.
+                Defaults to None.
+            logger (logging.Logger | str, optional): Logger used for printing
+                related information during evaluation. Defaults to None.
         Returns:
             dict: evaluation results
         """

--- a/mmcls/datasets/multi_label.py
+++ b/mmcls/datasets/multi_label.py
@@ -67,7 +67,7 @@ class MultiLabelDataset(BaseDataset):
 
         invalid_metrics = set(metrics) - set(allowed_metrics)
         if len(invalid_metrics) != 0:
-            raise ValueError(f'metirc {invalid_metrics} is not supported.')
+            raise ValueError(f'metric {invalid_metrics} is not supported.')
 
         if 'mAP' in metrics:
             mAP_value = mAP(results, gt_labels)

--- a/mmcls/datasets/multi_label.py
+++ b/mmcls/datasets/multi_label.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from mmcls.core import average_performance, mAP
@@ -21,7 +23,12 @@ class MultiLabelDataset(BaseDataset):
         cat_ids = np.where(gt_labels == 1)[0]
         return cat_ids
 
-    def evaluate(self, results, metric='mAP', logger=None, **eval_kwargs):
+    def evaluate(self,
+                 results,
+                 metric='mAP',
+                 metric_options=None,
+                 logger=None,
+                 **deprecated_kwargs):
         """Evaluate the dataset.
 
         Args:
@@ -29,11 +36,23 @@ class MultiLabelDataset(BaseDataset):
             metric (str | list[str]): Metrics to be evaluated.
                 Default value is 'mAP'. Options are 'mAP', 'CP', 'CR', 'CF1',
                 'OP', 'OR' and 'OF1'.
+            metric_options (dict): Options for calculating metrics. Allowed
+                keys are 'k' and 'thr'.
             logger (logging.Logger | None | str): Logger used for printing
                 related information during evaluation. Default: None.
+            deprecated_kwargs (dict): Used for containing deprecated arguments.
+
         Returns:
             dict: evaluation results
         """
+        if metric_options is None:
+            metric_options = {'thr': 0.5}
+
+        if deprecated_kwargs != {}:
+            warnings.warn('Option arguments for metrics has been changed to '
+                          '`metric_options`.')
+            metric_options = {**deprecated_kwargs}
+
         if isinstance(metric, str):
             metrics = [metric]
         else:
@@ -56,7 +75,7 @@ class MultiLabelDataset(BaseDataset):
         if len(set(metrics) - {'mAP'}) != 0:
             performance_keys = ['CP', 'CR', 'CF1', 'OP', 'OR', 'OF1']
             performance_values = average_performance(results, gt_labels,
-                                                     **eval_kwargs)
+                                                     **metric_options)
             for k, v in zip(performance_keys, performance_values):
                 if k in metrics:
                     eval_results[k] = v

--- a/mmcls/datasets/multi_label.py
+++ b/mmcls/datasets/multi_label.py
@@ -36,10 +36,10 @@ class MultiLabelDataset(BaseDataset):
             metric (str | list[str]): Metrics to be evaluated.
                 Default value is 'mAP'. Options are 'mAP', 'CP', 'CR', 'CF1',
                 'OP', 'OR' and 'OF1'.
-            metric_options (dict): Options for calculating metrics. Allowed
-                keys are 'k' and 'thr'.
-            logger (logging.Logger | None | str): Logger used for printing
-                related information during evaluation. Default: None.
+            metric_options (dict, optional): Options for calculating metrics.
+                Allowed keys are 'k' and 'thr'. Defaults to None
+            logger (logging.Logger | str, optional): Logger used for printing
+                related information during evaluation. Defaults to None.
             deprecated_kwargs (dict): Used for containing deprecated arguments.
 
         Returns:

--- a/tools/test.py
+++ b/tools/test.py
@@ -40,6 +40,14 @@ def parse_args():
         help='override some settings in the used config, the key-value pair '
         'in xxx=yyy format will be merged into config file.')
     parser.add_argument(
+        '--metric-options',
+        nargs='+',
+        action=DictAction,
+        default={},
+        help='custom options for evaluation, the key-value pair in xxx=yyy '
+        'format will be parsed as a dict metric_options for dataset.evaluate()'
+        ' function.')
+    parser.add_argument(
         '--launcher',
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
@@ -101,7 +109,8 @@ def main():
     rank, _ = get_dist_info()
     if rank == 0:
         if args.metrics:
-            results = dataset.evaluate(outputs, args.metrics)
+            results = dataset.evaluate(outputs, args.metrics,
+                                       args.metric_options)
             for k, v in results.items():
                 print(f'\n{k} : {v:.2f}')
         else:


### PR DESCRIPTION
Hi,
I have noticed that the metric_options argument in evaluate has different structure compared to other repos. And for different metrics, different metric_options should be set. So previously I intended to modify it to keep the consistency and make it clearer to users. 
However, for some metrics, e.g. CP, CR, CF1, OP, OR, OF1, it's weird to set different metric_options for them. So after consideration, I have decided to keep it the way as it is.
--eval-options is added in test.py and it is not merged with the config on purpose, because it seems unnatural to me to set --metrics but intend to use eval_options in config (because different metrics require different options). 

Pls kindly take a look. Thank you.