### PR TITLE
[Feature] Add shear pipeline

### DIFF
--- a/mmcls/datasets/pipelines/__init__.py
+++ b/mmcls/datasets/pipelines/__init__.py
@@ -1,3 +1,4 @@
+from .auto_augment import Shear
 from .compose import Compose
 from .formating import (Collect, ImageToTensor, ToNumpy, ToPIL, ToTensor,
                         Transpose, to_tensor)
@@ -9,5 +10,5 @@ __all__ = [
     'Compose', 'to_tensor', 'ToTensor', 'ImageToTensor', 'ToPIL', 'ToNumpy',
     'Transpose', 'Collect', 'LoadImageFromFile', 'Resize', 'CenterCrop',
     'RandomFlip', 'Normalize', 'RandomCrop', 'RandomResizedCrop',
-    'RandomGrayscale'
+    'RandomGrayscale', 'Shear'
 ]

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -1,0 +1,177 @@
+import copy
+
+import mmcv
+import numpy as np
+
+from ..builder import PIPELINES
+from .compose import Compose
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+cv2_allowed_interp = ['nearest', 'bilinear', 'bicubic', 'area', 'lanczos']
+
+if Image is not None:
+    pillow_interp_codes = {
+        'nearest': Image.NEAREST,
+        'bilinear': Image.BILINEAR,
+        'bicubic': Image.BICUBIC,
+        'box': Image.BOX,
+        'lanczos': Image.LANCZOS,
+        'hamming': Image.HAMMING
+    }
+    pillow_allowed_interp = [
+        'nearest', 'bilinear', 'bicubic', 'box', 'lanczos', 'hamming'
+    ]
+
+
+def random_negative(value, random_negative_prob):
+    """Randomly negate value based on random_negative_prob."""
+    return -value if np.random.rand() < random_negative_prob else value
+
+
+@PIPELINES.register_module()
+class AutoAugment(object):
+    """Auto Augmentation.
+
+    This data augmentation is proposed in `AutoAugment: Learning Augmentation
+    Strategies From Data <https://ieeexplore.ieee.org/document/8953317>`_.
+
+    Args:
+        policies (list[list[dict]]| str): The policies of auto augmentation.
+            When policies is list, each policy in ``policies`` is a specific
+            augmentation policy, and is composed by several augmentations
+            (dict). When AutoAugment is called, a random policy in ``policies``
+             will be selected to augment images. When policies is str, the
+            predetermined policies will be used.
+    """
+
+    def __init__(self, policies):
+        if isinstance(policies, str):
+            if policies == 'ImageNetPolicy':
+                policies = []  # to be fixed
+            elif policies == 'CifarPolicy':
+                policies = []  # to be fixed
+            else:
+                raise ValueError(f'Policies: {policies} is not supported for '
+                                 'auto augmentation. Supported policies are '
+                                 '"ImageNetPolicy", "CifarPolicy".')
+        assert isinstance(policies, list) and len(policies) > 0, \
+            'Policies must be a non-empty list.'
+        for policy in policies:
+            assert isinstance(policy, list) and len(policy) > 0, \
+                'Each policy in policies must be a non-empty list.'
+            for augment in policy:
+                assert isinstance(augment, dict) and 'type' in augment, \
+                    'Each specific augmentation must be a dict with key' \
+                    ' "type".'
+        self.policies = copy.deepcopy(policies)
+        self.transforms = [Compose(policy) for policy in self.policies]
+
+    def __call__(self, results):
+        transform = np.random.choice(self.transforms)
+        return transform(results)
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}(policies={self.policies})'
+
+
+PIPELINES.register_module()
+
+
+class Shear(object):
+    """Shear images.
+
+    Args:
+        magnitude (int | float): The magnitude used for shear.
+        pad_val (int, tuple[int]): Pixel pad_val value for constant fill. If a
+            tuple of length 3, it is used to pad_val R, G, B channels
+            respectively. Defaults to 128.
+        prob (float): The probability for performing Shear therefore should be
+            in range [0, 1]. Defaults to 0.5.
+        direction (str): The shearing direction. Options are 'horizontal' and
+            'vertical'. Default: 'horizontal'.
+        random_negative_prob (float): The probability that turns the magnitude
+            negative, which should be in range [0,1]. Defaults to 0.5.
+        interpolation (str): Interpolation method. Options are
+            "nearest", "bilinear", "bicubic", "area", "lanczos" for 'cv2'
+            backend, "nearest", "bilinear" for 'pillow' backend.
+            Defaults to 'bilinear'.
+        backend (str): The backend type used for shear. Options are
+            cv2 and pillow. Defaults to pillow.
+    """
+
+    def __init__(self,
+                 magnitude,
+                 pad_val=128,
+                 prob=0.5,
+                 direction='horizontal',
+                 random_negative_prob=0.5,
+                 interpolation='bilinear',
+                 backend='pillow'):
+        assert isinstance(magnitude, (int, float)), 'The magnitude type must '\
+            f'be int or float, but got {type(magnitude)} instead.'
+        if isinstance(pad_val, int):
+            pad_val = tuple([pad_val] * 3)
+        elif isinstance(pad_val, tuple):
+            assert len(pad_val) == 3, 'pad_val as a tuple must have 3 ' \
+                f'elements, got {len(pad_val)} instead.'
+            assert all(isinstance(i, int) for i in pad_val), 'pad_val as a '\
+                'tuple must got elements of int type.'
+        else:
+            raise TypeError('pad_val must be int or tuple with 3 elements.')
+        assert 0 <= prob <= 1.0, 'The prob should be in range [0,1], ' \
+            f'got {prob} instead.'
+        assert direction in ('horizontal', 'vertical'), 'direction must be ' \
+            f'either "horizontal" or "vertical", got {direction} instead.'
+        assert 0 <= random_negative_prob <= 1.0, 'The random_negative_prob ' \
+            f'should be in range [0,1], got {random_negative_prob} instead.'
+        if backend == 'cv2':
+            assert interpolation in cv2_allowed_interp
+        elif backend == 'pillow':
+            assert interpolation in pillow_allowed_interp
+        else:
+            raise ValueError(f'backend: {backend} is not supported for shear.'
+                             'Supported backends are "cv2", "pillow".')
+
+        self.magnitude = magnitude
+        self.pad_val = pad_val
+        self.prob = prob
+        self.direction = direction
+        self.random_negative_prob = random_negative_prob
+        self.interpolation = interpolation
+        self.backend = backend
+
+    def __call__(self, results):
+        magnitude = random_negative(self.magnitude, self.random_negative_prob)
+        for key in results.get('img_fields', ['img']):
+            if self.backend == 'cv2':
+                results[key] = mmcv.imshear(
+                    results[key],
+                    magnitude,
+                    border_value=self.pad_val,
+                    interpolation=self.interpolation)
+            else:
+                assert results[key].dtype == np.uint8, \
+                    'Pillow backend only support uint8 type'
+                interpolation = pillow_interp_codes[self.interpolation]
+                img_pil = Image.fromarray(results[key])
+                img_pil = img_pil.transform(
+                    img_pil.size,
+                    Image.AFFINE, (1, magnitude, 0, 0, 1, 0),
+                    interpolation,
+                    fillcolor=self.pad_val)
+                results[key] = np.array(img_pil)
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += f'(magnitude={self.magnitude}, '
+        repr_str += f'(pad_val={self.pad_val}, '
+        repr_str += f'(prob={self.prob}, '
+        repr_str += f'(direction={self.direction}, '
+        repr_str += f'(random_negative_prob={self.random_negative_prob}, '
+        repr_str += f'interpolation={self.interpolation}, '
+        repr_str += f'backend={self.backend}, '
+        return repr_str

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -21,7 +21,7 @@ class Shear(object):
         prob (float): The probability for performing Shear therefore should be
             in range [0, 1]. Defaults to 0.5.
         direction (str): The shearing direction. Options are 'horizontal' and
-            'vertical'. Default: 'horizontal'.
+            'vertical'. Defaults to 'horizontal'.
         random_negative_prob (float): The probability that turns the magnitude
             negative, which should be in range [0,1]. Defaults to 0.5.
         interpolation (str): Interpolation method. Options are 'nearest',

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -1,30 +1,7 @@
-import copy
-
 import mmcv
 import numpy as np
 
 from ..builder import PIPELINES
-from .compose import Compose
-
-try:
-    from PIL import Image
-except ImportError:
-    Image = None
-
-cv2_allowed_interp = ['nearest', 'bilinear', 'bicubic', 'area', 'lanczos']
-
-if Image is not None:
-    pillow_interp_codes = {
-        'nearest': Image.NEAREST,
-        'bilinear': Image.BILINEAR,
-        'bicubic': Image.BICUBIC,
-        'box': Image.BOX,
-        'lanczos': Image.LANCZOS,
-        'hamming': Image.HAMMING
-    }
-    pillow_allowed_interp = [
-        'nearest', 'bilinear', 'bicubic', 'box', 'lanczos', 'hamming'
-    ]
 
 
 def random_negative(value, random_negative_prob):
@@ -33,54 +10,6 @@ def random_negative(value, random_negative_prob):
 
 
 @PIPELINES.register_module()
-class AutoAugment(object):
-    """Auto Augmentation.
-
-    This data augmentation is proposed in `AutoAugment: Learning Augmentation
-    Strategies From Data <https://ieeexplore.ieee.org/document/8953317>`_.
-
-    Args:
-        policies (list[list[dict]]| str): The policies of auto augmentation.
-            When policies is list, each policy in ``policies`` is a specific
-            augmentation policy, and is composed by several augmentations
-            (dict). When AutoAugment is called, a random policy in ``policies``
-             will be selected to augment images. When policies is str, the
-            predetermined policies will be used.
-    """
-
-    def __init__(self, policies):
-        if isinstance(policies, str):
-            if policies == 'ImageNetPolicy':
-                policies = []  # to be fixed
-            elif policies == 'CifarPolicy':
-                policies = []  # to be fixed
-            else:
-                raise ValueError(f'Policies: {policies} is not supported for '
-                                 'auto augmentation. Supported policies are '
-                                 '"ImageNetPolicy", "CifarPolicy".')
-        assert isinstance(policies, list) and len(policies) > 0, \
-            'Policies must be a non-empty list.'
-        for policy in policies:
-            assert isinstance(policy, list) and len(policy) > 0, \
-                'Each policy in policies must be a non-empty list.'
-            for augment in policy:
-                assert isinstance(augment, dict) and 'type' in augment, \
-                    'Each specific augmentation must be a dict with key' \
-                    ' "type".'
-        self.policies = copy.deepcopy(policies)
-        self.transforms = [Compose(policy) for policy in self.policies]
-
-    def __call__(self, results):
-        transform = np.random.choice(self.transforms)
-        return transform(results)
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}(policies={self.policies})'
-
-
-PIPELINES.register_module()
-
-
 class Shear(object):
     """Shear images.
 
@@ -95,12 +24,8 @@ class Shear(object):
             'vertical'. Default: 'horizontal'.
         random_negative_prob (float): The probability that turns the magnitude
             negative, which should be in range [0,1]. Defaults to 0.5.
-        interpolation (str): Interpolation method. Options are
-            "nearest", "bilinear", "bicubic", "area", "lanczos" for 'cv2'
-            backend, "nearest", "bilinear" for 'pillow' backend.
-            Defaults to 'bilinear'.
-        backend (str): The backend type used for shear. Options are
-            cv2 and pillow. Defaults to pillow.
+        interpolation (str): Interpolation method. Options are 'nearest',
+            'bilinear', 'bicubic', 'area', 'lanczos'. Defaults to 'bicubic'.
     """
 
     def __init__(self,
@@ -109,8 +34,7 @@ class Shear(object):
                  prob=0.5,
                  direction='horizontal',
                  random_negative_prob=0.5,
-                 interpolation='bilinear',
-                 backend='pillow'):
+                 interpolation='bicubic'):
         assert isinstance(magnitude, (int, float)), 'The magnitude type must '\
             f'be int or float, but got {type(magnitude)} instead.'
         if isinstance(pad_val, int):
@@ -128,13 +52,6 @@ class Shear(object):
             f'either "horizontal" or "vertical", got {direction} instead.'
         assert 0 <= random_negative_prob <= 1.0, 'The random_negative_prob ' \
             f'should be in range [0,1], got {random_negative_prob} instead.'
-        if backend == 'cv2':
-            assert interpolation in cv2_allowed_interp
-        elif backend == 'pillow':
-            assert interpolation in pillow_allowed_interp
-        else:
-            raise ValueError(f'backend: {backend} is not supported for shear.'
-                             'Supported backends are "cv2", "pillow".')
 
         self.magnitude = magnitude
         self.pad_val = pad_val
@@ -142,28 +59,21 @@ class Shear(object):
         self.direction = direction
         self.random_negative_prob = random_negative_prob
         self.interpolation = interpolation
-        self.backend = backend
 
     def __call__(self, results):
+        if np.random.rand() > self.prob:
+            return results
         magnitude = random_negative(self.magnitude, self.random_negative_prob)
         for key in results.get('img_fields', ['img']):
-            if self.backend == 'cv2':
-                results[key] = mmcv.imshear(
-                    results[key],
-                    magnitude,
-                    border_value=self.pad_val,
-                    interpolation=self.interpolation)
-            else:
-                assert results[key].dtype == np.uint8, \
-                    'Pillow backend only support uint8 type'
-                interpolation = pillow_interp_codes[self.interpolation]
-                img_pil = Image.fromarray(results[key])
-                img_pil = img_pil.transform(
-                    img_pil.size,
-                    Image.AFFINE, (1, magnitude, 0, 0, 1, 0),
-                    interpolation,
-                    fillcolor=self.pad_val)
-                results[key] = np.array(img_pil)
+            img = results[key]
+            img_sheared = mmcv.imshear(
+                img,
+                magnitude,
+                direction=self.direction,
+                border_value=self.pad_val,
+                interpolation=self.interpolation)
+            results[key] = img_sheared.astype(img.dtype)
+        return results
 
     def __repr__(self):
         repr_str = self.__class__.__name__
@@ -172,6 +82,5 @@ class Shear(object):
         repr_str += f'(prob={self.prob}, '
         repr_str += f'(direction={self.direction}, '
         repr_str += f'(random_negative_prob={self.random_negative_prob}, '
-        repr_str += f'interpolation={self.interpolation}, '
-        repr_str += f'backend={self.backend}, '
+        repr_str += f'interpolation={self.interpolation})'
         return repr_str

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -78,9 +78,9 @@ class Shear(object):
     def __repr__(self):
         repr_str = self.__class__.__name__
         repr_str += f'(magnitude={self.magnitude}, '
-        repr_str += f'(pad_val={self.pad_val}, '
-        repr_str += f'(prob={self.prob}, '
-        repr_str += f'(direction={self.direction}, '
-        repr_str += f'(random_negative_prob={self.random_negative_prob}, '
+        repr_str += f'pad_val={self.pad_val}, '
+        repr_str += f'prob={self.prob}, '
+        repr_str += f'direction={self.direction}, '
+        repr_str += f'random_negative_prob={self.random_negative_prob}, '
         repr_str += f'interpolation={self.interpolation})'
         return repr_str

--- a/tests/test_pipelines/test_auto_augment.py
+++ b/tests/test_pipelines/test_auto_augment.py
@@ -8,7 +8,8 @@ from mmcls.datasets.builder import PIPELINES
 
 
 def construct_toy_data():
-    img = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.uint8)
+    img = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+                   dtype=np.uint8)
     img = np.stack([img, img, img], axis=-1)
     results = dict()
     # image
@@ -67,7 +68,8 @@ def test_shear():
         type='Shear', magnitude=1, pad_val=0, prob=1., random_negative_prob=0.)
     pipeline = build_from_cfg(transform, PIPELINES)
     results = pipeline(results)
-    sheared_img = np.array([[1, 2, 3], [0, 4, 5], [0, 0, 7]], dtype=np.uint8)
+    sheared_img = np.array([[1, 2, 3, 4], [0, 5, 6, 7], [0, 0, 9, 10]],
+                           dtype=np.uint8)
     sheared_img = np.stack([sheared_img, sheared_img, sheared_img], axis=-1)
     assert (results['img'] == sheared_img).all()
     assert (results['img'] == results['img2']).all()
@@ -83,7 +85,8 @@ def test_shear():
         random_negative_prob=0.)
     pipeline = build_from_cfg(transform, PIPELINES)
     results = pipeline(results)
-    sheared_img = np.array([[1, 5, 9], [4, 8, 0], [7, 0, 0]], dtype=np.uint8)
+    sheared_img = np.array([[1, 6, 11, 0], [5, 10, 0, 0], [9, 0, 0, 0]],
+                           dtype=np.uint8)
     sheared_img = np.stack([sheared_img, sheared_img, sheared_img], axis=-1)
     assert (results['img'] == sheared_img).all()
 
@@ -98,6 +101,7 @@ def test_shear():
         random_negative_prob=1.)
     pipeline = build_from_cfg(transform, PIPELINES)
     results = pipeline(results)
-    sheared_img = np.array([[1, 5, 9], [4, 8, 0], [7, 0, 0]], dtype=np.uint8)
+    sheared_img = np.array([[1, 6, 11, 0], [5, 10, 0, 0], [9, 0, 0, 0]],
+                           dtype=np.uint8)
     sheared_img = np.stack([sheared_img, sheared_img, sheared_img], axis=-1)
     assert (results['img'] == sheared_img).all()

--- a/tests/test_pipelines/test_auto_augment.py
+++ b/tests/test_pipelines/test_auto_augment.py
@@ -1,0 +1,103 @@
+import copy
+
+import numpy as np
+import pytest
+from mmcv.utils import build_from_cfg
+
+from mmcls.datasets.builder import PIPELINES
+
+
+def construct_toy_data():
+    img = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.uint8)
+    img = np.stack([img, img, img], axis=-1)
+    results = dict()
+    # image
+    results['ori_img'] = img
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    results['img_fields'] = ['img', 'img2']
+    return results
+
+
+def test_shear():
+    # test assertion for invalid type of magnitude
+    with pytest.raises(AssertionError):
+        transform = dict(type='Shear', magnitude=None)
+        build_from_cfg(transform, PIPELINES)
+
+    # test assertion for invalid pad_val
+    with pytest.raises(AssertionError):
+        transform = dict(type='Shear', magnitude=0.5, pad_val=(0, 0))
+        build_from_cfg(transform, PIPELINES)
+
+    # test assertion for invalid value of prob
+    with pytest.raises(AssertionError):
+        transform = dict(type='Shear', magnitude=0.5, prob=100)
+        build_from_cfg(transform, PIPELINES)
+
+    # test assertion for invalid direction
+    with pytest.raises(AssertionError):
+        transform = dict(type='Shear', magnitude=0.5, direction='diagonal')
+        build_from_cfg(transform, PIPELINES)
+
+    # test assertion for invalid value of random_negative_prob
+    with pytest.raises(AssertionError):
+        transform = dict(type='Shear', magnitude=0.5, random_negative_prob=100)
+        build_from_cfg(transform, PIPELINES)
+
+    # test case when magnitude = 0, therefore no shear
+    results = construct_toy_data()
+    transform = dict(type='Shear', magnitude=0., prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when prob = 0, therefore no shear
+    results = construct_toy_data()
+    transform = dict(type='Shear', magnitude=0.5, prob=0.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test shear horizontally, magnitude=1
+    results = construct_toy_data()
+    transform = dict(
+        type='Shear', magnitude=1, pad_val=0, prob=1., random_negative_prob=0.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    sheared_img = np.array([[1, 2, 3], [0, 4, 5], [0, 0, 7]], dtype=np.uint8)
+    sheared_img = np.stack([sheared_img, sheared_img, sheared_img], axis=-1)
+    assert (results['img'] == sheared_img).all()
+    assert (results['img'] == results['img2']).all()
+
+    # test shear vertically, magnitude=-1
+    results = construct_toy_data()
+    transform = dict(
+        type='Shear',
+        magnitude=-1,
+        pad_val=0,
+        prob=1.,
+        direction='vertical',
+        random_negative_prob=0.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    sheared_img = np.array([[1, 5, 9], [4, 8, 0], [7, 0, 0]], dtype=np.uint8)
+    sheared_img = np.stack([sheared_img, sheared_img, sheared_img], axis=-1)
+    assert (results['img'] == sheared_img).all()
+
+    # test shear vertically, magnitude=1, random_negative_prob=1
+    results = construct_toy_data()
+    transform = dict(
+        type='Shear',
+        magnitude=1,
+        pad_val=0,
+        prob=1.,
+        direction='vertical',
+        random_negative_prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    sheared_img = np.array([[1, 5, 9], [4, 8, 0], [7, 0, 0]], dtype=np.uint8)
+    sheared_img = np.stack([sheared_img, sheared_img, sheared_img], axis=-1)
+    assert (results['img'] == sheared_img).all()


### PR DESCRIPTION
Hi,
In this pull request, Shear pipeline is added. 
This pull request serves as a sub-task for implementing auto-augmentation, therefore there are several things to note:
1. Most auto-augmentation implementation is based on pillow backend, however mmcv image transforms are mostly based on cv2 backend. After a comparison of those two, I found them different yet the difference is not awfully significant. Therefore I decided to first simply wrap mmcv transform in pipeline and see if the performance matches. 
2. Pipelines needed are listed below.
    - [x] Shear
    - [ ] Translate
    - [ ] Rotate
    - [ ] AutoContrast
    - [ ] Invert
    - [ ] Equalize
    - [ ] Solarize
    - [ ] Posterize
    - [ ] Contrast
    - [ ] Color
    - [ ] Brightness
    - [ ] Sharpness
   
Please kindly take a look. Thank you.