### PR TITLE
[Fix] Remove pytest configuration in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@ universal=1
 [aliases]
 test=pytest
 
-[tool:pytest]
-addopts=tests/
-
 [yapf]
 based_on_style = pep8
 blank_line_before_nested_class_or_def = true


### PR DESCRIPTION
Hi, 
This pull request removes pytest configuration in setup.cfg. The current setting makes it inconvenient to specify test files when running pytest.
It seems to me that it should be set as `testpaths = tests/` instead of `addopts=tests/`, however that is also not necessary since the default `testpaths` is already `tests/`. So it is simply removed.

Pls kindly take a look. Thank you.