### PR TITLE
Bump version to 0.9.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project is released under the [Apache 2.0 license](LICENSE).
 
 ## Changelog
 
-v0.8.0 was released in 31/1/2021.
+v0.9.0 was released in 1/3/2021.
 Please refer to [changelog.md](docs/changelog.md) for details and release history.
 
 ## Benchmark and model zoo

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,12 +3,14 @@
 ### v0.9.0(1/3/2021)
 
 - Implement mixup trick.
+- Add a new tool to create TensorRT engine from ONNX, run inference and verify outputs in Python.
 
 #### New Features
 
 - Implement mixup and provide configs of training ResNet50 using mixup. (#160)
 - Add `Shear` pipeline for data augmentation. (#163)
 - Add `Translate` pipeline for data augmentation. (#165)
+- Add `tools/onnx2tensorrt.py` as a tool to create TensorRT engine from ONNX, run inference and verify outputs in Python. (#153)
 
 #### Improvements
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,24 @@
 ## Changelog
 
+### v0.9.0(1/3/2021)
+
+- Implement mixup trick.
+
+#### New Features
+
+- Implement mixup and provide configs of training ResNet50 using mixup. (#160)
+- Add `Shear` pipeline for data augmentation. (#163)
+- Add `Translate` pipeline for data augmentation. (#165)
+
+#### Improvements
+
+- Add `--eval-options` in `tools/test.py` to support eval options override, matching the behavior of other open-mmlab projects. (#158)
+- Support showing and saving painted results in `mmcls.apis.test` and `tools/test.py`, matching the behavior of other open-mmlab projects. (#162)
+
+#### Bug Fixes
+
+- Fix configs for VGG, replace checkpoints converted from other repos with the ones trained by ourselves and upload the missing logs in the model zoo. (#161)
+
 ### v0.8.0(31/1/2021)
 
 - Support multi-label task.

--- a/mmcls/version.py
+++ b/mmcls/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 
-__version__ = '0.8.0'
+__version__ = '0.9.0'
 
 
 def parse_version_info(version_str):


### PR DESCRIPTION
Hi Xiongyu,

Docs are updated for version 0.9.0 in this pull request.
#164 is skipped since it should not be of users' concerns.

Pls kindly take a look. Thank you.