### PR TITLE
[Feature] Support solarize and posterize pipelines

### DIFF
--- a/mmcls/datasets/pipelines/__init__.py
+++ b/mmcls/datasets/pipelines/__init__.py
@@ -1,4 +1,4 @@
-from .auto_augment import Invert, Rotate, Shear, Translate
+from .auto_augment import Invert, Posterize, Rotate, Shear, Solarize, Translate
 from .compose import Compose
 from .formating import (Collect, ImageToTensor, ToNumpy, ToPIL, ToTensor,
                         Transpose, to_tensor)
@@ -10,5 +10,6 @@ __all__ = [
     'Compose', 'to_tensor', 'ToTensor', 'ImageToTensor', 'ToPIL', 'ToNumpy',
     'Transpose', 'Collect', 'LoadImageFromFile', 'Resize', 'CenterCrop',
     'RandomFlip', 'Normalize', 'RandomCrop', 'RandomResizedCrop',
-    'RandomGrayscale', 'Shear', 'Translate', 'Rotate', 'Invert'
+    'RandomGrayscale', 'Shear', 'Translate', 'Rotate', 'Invert', 'Solarize',
+    'Posterize'
 ]

--- a/mmcls/datasets/pipelines/__init__.py
+++ b/mmcls/datasets/pipelines/__init__.py
@@ -1,4 +1,5 @@
-from .auto_augment import ColorTransform, Invert, Rotate, Shear, Translate
+from .auto_augment import (ColorTransform, Invert, Posterize, Rotate, Shear,
+                           Solarize, Translate)
 from .compose import Compose
 from .formating import (Collect, ImageToTensor, ToNumpy, ToPIL, ToTensor,
                         Transpose, to_tensor)
@@ -11,5 +12,5 @@ __all__ = [
     'Transpose', 'Collect', 'LoadImageFromFile', 'Resize', 'CenterCrop',
     'RandomFlip', 'Normalize', 'RandomCrop', 'RandomResizedCrop',
     'RandomGrayscale', 'Shear', 'Translate', 'Rotate', 'Invert',
-    'ColorTransform'
+    'ColorTransform', 'Solarize', 'Posterize'
 ]

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -331,7 +331,8 @@ class Posterize(object):
     """Posterize an image (reduce the number of bits for each color channel).
 
     Args:
-        bits (int): Number of bits for each pixel in the output img.
+        bits (int): Number of bits for each pixel in the output img, which
+            should be less or equal to 8.
         prob (float): The probability for posterizing therefore should be in
             range [0, 1]. Defaults to 0.5.
     """

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -288,3 +288,75 @@ class Invert(object):
         repr_str = self.__class__.__name__
         repr_str += f'(prob={self.prob})'
         return repr_str
+
+
+@PIPELINES.register_module()
+class Solarize(object):
+    """Solarize an image (invert all pixel values above a threshold).
+
+    Args:
+        thr (int | float): The threshold above which the pixels value will be
+            inverted.
+        prob (float): The probability for solarizing therefore should be in
+            range [0, 1]. Defaults to 0.5.
+    """
+
+    def __init__(self, thr, prob=0.5):
+        assert isinstance(thr, (int, float)), 'The thr type must '\
+            f'be int or float, but got {type(thr)} instead.'
+        assert 0 <= prob <= 1.0, 'The prob should be in range [0,1], ' \
+            f'got {prob} instead.'
+
+        self.thr = thr
+        self.prob = prob
+
+    def __call__(self, results):
+        if np.random.rand() > self.prob:
+            return results
+        for key in results.get('img_fields', ['img']):
+            img = results[key]
+            img_solarized = mmcv.solarize(img, thr=self.thr)
+            results[key] = img_solarized.astype(img.dtype)
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += f'(thr={self.thr}, '
+        repr_str += f'prob={self.prob})'
+        return repr_str
+
+
+@PIPELINES.register_module()
+class Posterize(object):
+    """Posterize an image (reduce the number of bits for each color channel).
+
+    Args:
+        bits (int): Number of bits for each pixel in the output img.
+        prob (float): The probability for posterizing therefore should be in
+            range [0, 1]. Defaults to 0.5.
+    """
+
+    def __init__(self, bits, prob=0.5):
+        assert isinstance(bits, int), 'The bits type must be int, '\
+            f'but got {type(bits)} instead.'
+        assert bits <= 8, f'The bits must be less than 8, got {bits} instead.'
+        assert 0 <= prob <= 1.0, 'The prob should be in range [0,1], ' \
+            f'got {prob} instead.'
+
+        self.bits = bits
+        self.prob = prob
+
+    def __call__(self, results):
+        if np.random.rand() > self.prob:
+            return results
+        for key in results.get('img_fields', ['img']):
+            img = results[key]
+            img_posterized = mmcv.posterize(img, bits=self.bits)
+            results[key] = img_posterized.astype(img.dtype)
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += f'(bits={self.bits}, '
+        repr_str += f'prob={self.prob})'
+        return repr_str

--- a/tests/test_pipelines/test_auto_augment.py
+++ b/tests/test_pipelines/test_auto_augment.py
@@ -417,3 +417,98 @@ def test_color_transform():
                 255)).astype(results['ori_img'].dtype)
     assert (results['img'] == img_r).all()
     assert (results['img'] == results['img2']).all()
+
+
+def test_solarize():
+    # test assertion for invalid type of thr
+    with pytest.raises(AssertionError):
+        transform = dict(type='Solarize', thr=(1, 2))
+        build_from_cfg(transform, PIPELINES)
+
+    # test case when prob=0, therefore no solarize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=128, prob=0.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when thr=256, therefore no solarize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=256, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when thr=128
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=128, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_solarized = np.array([[0, 127, 0], [1, 127, 1], [2, 126, 2]],
+                             dtype=np.uint8)
+    img_solarized = np.stack([img_solarized, img_solarized, img_solarized],
+                             axis=-1)
+    assert (results['img'] == img_solarized).all()
+    assert (results['img'] == results['img2']).all()
+
+    # test case when thr=100
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=100, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_solarized = np.array([[0, 127, 0], [1, 128, 1], [2, 126, 2]],
+                             dtype=np.uint8)
+    img_solarized = np.stack([img_solarized, img_solarized, img_solarized],
+                             axis=-1)
+    assert (results['img'] == img_solarized).all()
+    assert (results['img'] == results['img2']).all()
+
+
+def test_posterize():
+    # test assertion for invalid type of bits
+    with pytest.raises(AssertionError):
+        transform = dict(type='Posterize', bits=4.5)
+        build_from_cfg(transform, PIPELINES)
+
+    # test assertion for invalid value of bits
+    with pytest.raises(AssertionError):
+        transform = dict(type='Posterize', bits=10)
+        build_from_cfg(transform, PIPELINES)
+
+    # test case when prob=0, therefore no posterize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=4, prob=0.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when bits=8, therefore no solarize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=8, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when bits=1
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=1, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_posterized = np.array([[0, 128, 128], [0, 0, 128], [0, 128, 128]],
+                              dtype=np.uint8)
+    img_posterized = np.stack([img_posterized, img_posterized, img_posterized],
+                              axis=-1)
+    assert (results['img'] == img_posterized).all()
+    assert (results['img'] == results['img2']).all()
+
+    # test case when bits=3
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=3, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_posterized = np.array([[0, 128, 224], [0, 96, 224], [0, 128, 224]],
+                              dtype=np.uint8)
+    img_posterized = np.stack([img_posterized, img_posterized, img_posterized],
+                              axis=-1)
+    assert (results['img'] == img_posterized).all()
+    assert (results['img'] == results['img2']).all()

--- a/tests/test_pipelines/test_auto_augment.py
+++ b/tests/test_pipelines/test_auto_augment.py
@@ -22,6 +22,21 @@ def construct_toy_data():
     return results
 
 
+def construct_toy_data_photometric():
+    img = np.array([[0, 128, 255], [1, 127, 254], [2, 129, 253]],
+                   dtype=np.uint8)
+    img = np.stack([img, img, img], axis=-1)
+    results = dict()
+    # image
+    results['ori_img'] = img
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    results['img_fields'] = ['img', 'img2']
+    return results
+
+
 def test_shear():
     # test assertion for invalid type of magnitude
     with pytest.raises(AssertionError):
@@ -334,4 +349,99 @@ def test_invert():
     inverted_img = np.stack([inverted_img, inverted_img, inverted_img],
                             axis=-1)
     assert (results['img'] == inverted_img).all()
+    assert (results['img'] == results['img2']).all()
+
+
+def test_solarize():
+    # test assertion for invalid type of thr
+    with pytest.raises(AssertionError):
+        transform = dict(type='Solarize', thr=(1, 2))
+        build_from_cfg(transform, PIPELINES)
+
+    # test case when prob=0, therefore no solarize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=128, prob=0.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when thr=256, therefore no solarize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=256, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when thr=128
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=128, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_solarized = np.array([[0, 127, 0], [1, 127, 1], [2, 126, 2]],
+                             dtype=np.uint8)
+    img_solarized = np.stack([img_solarized, img_solarized, img_solarized],
+                             axis=-1)
+    assert (results['img'] == img_solarized).all()
+    assert (results['img'] == results['img2']).all()
+
+    # test case when thr=100
+    results = construct_toy_data_photometric()
+    transform = dict(type='Solarize', thr=100, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_solarized = np.array([[0, 127, 0], [1, 128, 1], [2, 126, 2]],
+                             dtype=np.uint8)
+    img_solarized = np.stack([img_solarized, img_solarized, img_solarized],
+                             axis=-1)
+    assert (results['img'] == img_solarized).all()
+    assert (results['img'] == results['img2']).all()
+
+
+def test_posterize():
+    # test assertion for invalid type of bits
+    with pytest.raises(AssertionError):
+        transform = dict(type='Posterize', bits=4.5)
+        build_from_cfg(transform, PIPELINES)
+
+    # test assertion for invalid value of bits
+    with pytest.raises(AssertionError):
+        transform = dict(type='Posterize', bits=10)
+        build_from_cfg(transform, PIPELINES)
+
+    # test case when prob=0, therefore no posterize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=4, prob=0.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when bits=8, therefore no solarize
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=8, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    assert (results['img'] == results['ori_img']).all()
+
+    # test case when bits=1
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=1, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_posterized = np.array([[0, 128, 128], [0, 0, 128], [0, 128, 128]],
+                              dtype=np.uint8)
+    img_posterized = np.stack([img_posterized, img_posterized, img_posterized],
+                              axis=-1)
+    assert (results['img'] == img_posterized).all()
+    assert (results['img'] == results['img2']).all()
+
+    # test case when bits=3
+    results = construct_toy_data_photometric()
+    transform = dict(type='Posterize', bits=3, prob=1.)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    results = pipeline(results)
+    img_posterized = np.array([[0, 128, 224], [0, 96, 224], [0, 128, 224]],
+                              dtype=np.uint8)
+    img_posterized = np.stack([img_posterized, img_posterized, img_posterized],
+                              axis=-1)
+    assert (results['img'] == img_posterized).all()
     assert (results['img'] == results['img2']).all()


### PR DESCRIPTION
Hi,
In this pull request, Solarize pipeline and Posterize pipeline are added. 
This pull request serves as a sub-task for implementing auto-augmentation. 
Pipelines needed are listed below.
 - [x] Shear
 - [x] Translate
 - [x] Rotate
 - [ ] AutoContrast (rely on open-mmlab/mmcv#881)
 - [x] Invert
 - [ ] Equalize (rely on open-mmlab/mmcv#863)
 - [x] Solarize
 - [x] Posterize
 - [ ] Contrast (rely on open-mmlab/mmcv#863)
 - [x] Color
 - [ ] Brightness (rely on open-mmlab/mmcv#863)
 - [ ] Sharpness (rely on open-mmlab/mmcv#864)

This pull request may have conflicts with #171, I will resolve them after #171 is merged.
Please kindly take a look. Thank you.

Another thing to note is that when bumping version, we might need to update docs for version compatibility with mmcv accordingly. 