### PR TITLE
[Fix] Use MMCV's EvalHook in MMClassification

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -6,16 +6,25 @@ import torch
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import DistSamplerSeedHook, build_optimizer, build_runner
 
-from mmcls.core import DistEvalHook, DistOptimizerHook, EvalHook
+from mmcls.core import DistOptimizerHook
 from mmcls.datasets import build_dataloader, build_dataset
 from mmcls.utils import get_root_logger
+
+# TODO import eval hooks from mmcv and delete them from mmcls
+try:
+    from mmcv.runner.hooks import EvalHook, DistEvalHook
+except ImportError:
+    warnings.warn('DeprecationWarning: EvalHook and DistEvalHook from mmcls '
+                  'will be deprecated.'
+                  'Please install mmcv through master branch.')
+    from mmcls.core import EvalHook, DistEvalHook
 
 # TODO import optimizer hook from mmcv and delete them from mmcls
 try:
     from mmcv.runner import Fp16OptimizerHook
 except ImportError:
-    warnings.warn('FP16OptimizerHook from mmcls will be deprecated.'
-                  'Please install mmcv>=1.1.4.')
+    warnings.warn('DeprecationWarning: FP16OptimizerHook from mmcls will be '
+                  'deprecated. Please install mmcv>=1.1.4.')
     from mmcls.core import Fp16OptimizerHook
 
 

--- a/mmcls/core/evaluation/eval_hooks.py
+++ b/mmcls/core/evaluation/eval_hooks.py
@@ -4,15 +4,8 @@ import warnings
 from mmcv.runner import Hook
 from torch.utils.data import DataLoader
 
-try:
-    from mmcv.runner import EvalHook, DistEvalHook  # noqa: F811
-except ImportError:
-    warnings.warn(
-        'DeprecationWarning: EvalHook and DistEvalHook in mmcls will be  '
-        'deprecated, please install mmcv through master branch.')
 
-
-class EvalHook(Hook):  # noqa: F811
+class EvalHook(Hook):
     """Evaluation hook.
 
     Args:
@@ -21,6 +14,9 @@ class EvalHook(Hook):  # noqa: F811
     """
 
     def __init__(self, dataloader, interval=1, by_epoch=True, **eval_kwargs):
+        warnings.warn(
+            'DeprecationWarning: EvalHook and DistEvalHook in mmcls will be '
+            'deprecated, please install mmcv through master branch.')
         if not isinstance(dataloader, DataLoader):
             raise TypeError('dataloader must be a pytorch DataLoader, but got'
                             f' {type(dataloader)}')
@@ -52,7 +48,7 @@ class EvalHook(Hook):  # noqa: F811
         runner.log_buffer.ready = True
 
 
-class DistEvalHook(EvalHook):  # noqa: F811
+class DistEvalHook(EvalHook):
     """Distributed evaluation hook.
 
     Args:
@@ -70,6 +66,9 @@ class DistEvalHook(EvalHook):  # noqa: F811
                  gpu_collect=False,
                  by_epoch=True,
                  **eval_kwargs):
+        warnings.warn(
+            'DeprecationWarning: EvalHook and DistEvalHook in mmcls will be '
+            'deprecated, please install mmcv through master branch.')
         if not isinstance(dataloader, DataLoader):
             raise TypeError('dataloader must be a pytorch DataLoader, but got '
                             f'{type(dataloader)}')

--- a/mmcls/core/evaluation/eval_hooks.py
+++ b/mmcls/core/evaluation/eval_hooks.py
@@ -1,10 +1,18 @@
 import os.path as osp
+import warnings
 
 from mmcv.runner import Hook
 from torch.utils.data import DataLoader
 
+try:
+    from mmcv.runner import EvalHook, DistEvalHook  # noqa: F811
+except ImportError:
+    warnings.warn(
+        'DeprecationWarning: EvalHook and DistEvalHook in mmcls will be  '
+        'deprecated, please install mmcv through master branch.')
 
-class EvalHook(Hook):
+
+class EvalHook(Hook):  # noqa: F811
     """Evaluation hook.
 
     Args:
@@ -44,7 +52,7 @@ class EvalHook(Hook):
         runner.log_buffer.ready = True
 
 
-class DistEvalHook(EvalHook):
+class DistEvalHook(EvalHook):  # noqa: F811
     """Distributed evaluation hook.
 
     Args:


### PR DESCRIPTION
Hi,
This pull request uses EvalHook from mmcv(open-mmlab/mmcv#739) to replace ones in mmcls. Both are supported for mmcls v0.10.0, but the after that, `EvalHook` and `DistEvalHook` will be removed.

Pls kindly take a look. Thx.