### PR TITLE
GlabelAveragePooling support 1d, 2d and 3d by  param, and add neck test

### DIFF
--- a/mmcls/models/necks/gap.py
+++ b/mmcls/models/necks/gap.py
@@ -13,9 +13,16 @@ class GlobalAveragePooling(nn.Module):
     has a batch dimension of size 1, which can lead to unexpected errors.
     """
 
-    def __init__(self):
+    def __init__(self, mode='2d'):
         super(GlobalAveragePooling, self).__init__()
-        self.gap = nn.AdaptiveAvgPool2d((1, 1))
+        if mode == '1d':
+            self.gap = nn.AdaptiveAvgPool1d(1)
+        elif mode == '2d':
+            self.gap = nn.AdaptiveAvgPool2d((1, 1))
+        elif mode == '3d':
+            self.gap = nn.AdaptiveAvgPool3d((1, 1, 1))
+        else:
+            raise NotImplementedError('Only support mode 1d, 2d and 3d')
 
     def init_weights(self):
         pass

--- a/tests/test_neck.py
+++ b/tests/test_neck.py
@@ -1,0 +1,33 @@
+import torch
+
+from mmcls.models.necks import GlobalAveragePooling
+
+
+def test_gap_neck():
+
+    # test 1d gap_neck
+    neck = GlobalAveragePooling(mode='1d')
+    # batch_size, num_features, feature_size
+    fake_input = torch.rand(1, 16, 24)
+
+    output = neck(fake_input)
+    # batch_size, num_features
+    assert output.shape == (1, 16)
+
+    # test 1d gap_neck
+    neck = GlobalAveragePooling(mode='2d')
+    # batch_size, num_features, feature_size(2)
+    fake_input = torch.rand(1, 16, 24, 24)
+
+    output = neck(fake_input)
+    # batch_size, num_features
+    assert output.shape == (1, 16)
+
+    # test 1d gap_neck
+    neck = GlobalAveragePooling(mode='3d')
+    # batch_size, num_features, feature_size(3)
+    fake_input = torch.rand(1, 16, 24, 24, 5)
+
+    output = neck(fake_input)
+    # batch_size, num_features
+    assert output.shape == (1, 16)


### PR DESCRIPTION
Add param `mode="1d"/"2d"/"3d"` to GlobalAveragePooling.