### PR TITLE
[Feature] Add RandAUG magnitude noise

### DIFF
--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -1,5 +1,6 @@
 import copy
 import random
+from numbers import Number
 
 import mmcv
 import numpy as np
@@ -74,12 +75,20 @@ class RandAugment(object):
             selected.
         total_level (int | float): Total level for the magnitude. Defaults to
             30.
+        magnitude_std (Number | str): Deviation of magnitude noise applied.
+            If positive number, magnitude is moved as normal distribution.
+            If str "inf", magnitude is moved as uniform distribution.
+
+    Note:
+        `magnitude_std` will introduce some randomness to policy, modified by
+        https://github.com/rwightman/pytorch-image-models
     """
 
     def __init__(self,
                  policies,
                  num_policies,
                  magnitude_level,
+                 magnitude_std=0.,
                  total_level=30):
         assert isinstance(num_policies, int), 'Number of policies must be ' \
             f'of int type, got {type(num_policies)} instead.'
@@ -94,12 +103,21 @@ class RandAugment(object):
             assert isinstance(policy, dict) and 'type' in policy, \
                 'Each policy must be a dict with key "type".'
 
+        assert isinstance(magnitude_std, (Number, str)), \
+            'Magnitude std must be of number or str type, ' \
+            f'got {type(magnitude_std)} instead.'
+        if isinstance(magnitude_std, str):
+            assert magnitude_std == 'inf', \
+                'Magnitude std must be of number or "inf", ' \
+                f'got "{magnitude_std}" instead.'
+
         assert num_policies > 0, 'num_policies must be greater than 0.'
         assert magnitude_level >= 0, 'magnitude_level must be no less than 0.'
         assert total_level > 0, 'total_level must be greater than 0.'
 
         self.num_policies = num_policies
         self.magnitude_level = magnitude_level
+        self.magnitude_std = magnitude_std
         self.total_level = total_level
         self.policies = self._process_policies(policies)
 
@@ -110,9 +128,17 @@ class RandAugment(object):
             magnitude_key = processed_policy.pop('magnitude_key', None)
             if magnitude_key is not None:
                 minval, maxval = processed_policy.pop('magnitude_range')
-                magnitude_value = (float(self.magnitude_level) /
-                                   self.total_level) * float(maxval -
-                                                             minval) + minval
+                magnitude_value = (self.magnitude_level / self.total_level
+                                   ) * float(maxval - minval) + minval
+
+                # if magnitude_std is positive number or 'inf', move
+                # magnitude_value randomly.
+                if self.magnitude_std == 'inf':
+                    magnitude_value = random.uniform(minval, magnitude_value)
+                elif self.magnitude_std > 0:
+                    magnitude_value = random.gauss(magnitude_value,
+                                                   self.magnitude_std)
+                    magnitude_value = min(maxval, max(0, magnitude_value))
                 processed_policy.update({magnitude_key: magnitude_value})
             processed_policies.append(processed_policy)
         return processed_policies

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -76,8 +76,11 @@ class RandAugment(object):
         total_level (int | float): Total level for the magnitude. Defaults to
             30.
         magnitude_std (Number | str): Deviation of magnitude noise applied.
-            If positive number, magnitude is moved as normal distribution.
-            If str "inf", magnitude is moved as uniform distribution.
+            If positive number, magnitude is sampled from normal distribution
+                (mean=magnitude, std=magnitude_std).
+            If 0 or negative number, magnitude remains unchanged.
+            If str "inf", magnitude is sampled from uniform distribution
+                (range=[min, magnitude]).
 
     Note:
         `magnitude_std` will introduce some randomness to policy, modified by

--- a/tests/test_pipelines/test_auto_augment.py
+++ b/tests/test_pipelines/test_auto_augment.py
@@ -85,6 +85,23 @@ def test_rand_augment():
             num_policies=1,
             magnitude_level=-1)
         build_from_cfg(transform, PIPELINES)
+    # test assertion for magnitude_std
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='RandAugment',
+            policies=policies,
+            num_policies=1,
+            magnitude_level=12,
+            magnitude_std=None)
+        build_from_cfg(transform, PIPELINES)
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='RandAugment',
+            policies=policies,
+            num_policies=1,
+            magnitude_level=12,
+            magnitude_std='unknown')
+        build_from_cfg(transform, PIPELINES)
     # test assertion for total_level
     with pytest.raises(AssertionError):
         transform = dict(
@@ -220,6 +237,66 @@ def test_rand_augment():
     results = pipeline(results)
     # apply rotate and translate
     assert (results['img'] == results['ori_img']).all()
+
+    # test case where magnitude_std = "inf"
+    random.seed(0)
+    np.random.seed(0)
+    results = construct_toy_data()
+    transform = dict(
+        type='RandAugment',
+        policies=policies,
+        num_policies=2,
+        magnitude_level=12,
+        magnitude_std='inf')
+    pipeline = build_from_cfg(transform, PIPELINES)
+    # apply invert and translate (magnitude=0.3378)
+    results = pipeline(results)
+    img_augmented = np.array(
+        [[128, 254, 253, 252], [128, 250, 249, 248], [128, 246, 245, 244]],
+        dtype=np.uint8)
+    img_augmented = np.stack([img_augmented, img_augmented, img_augmented],
+                             axis=-1)
+    np.testing.assert_array_equal(results['img'], img_augmented)
+
+    # test case where magnitude_std = 0.5
+    random.seed(0)
+    np.random.seed(0)
+    results = construct_toy_data()
+    transform = dict(
+        type='RandAugment',
+        policies=policies,
+        num_policies=2,
+        magnitude_level=12,
+        magnitude_std=0.5)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    # apply invert and translate (magnitude=0.8709)
+    results = pipeline(results)
+    img_augmented = np.array(
+        [[128, 128, 128, 254], [128, 128, 128, 250], [128, 128, 128, 246]],
+        dtype=np.uint8)
+    img_augmented = np.stack([img_augmented, img_augmented, img_augmented],
+                             axis=-1)
+    np.testing.assert_array_equal(results['img'], img_augmented)
+
+    # test case where magnitude_std is negtive
+    random.seed(3)
+    np.random.seed(0)
+    results = construct_toy_data()
+    transform = dict(
+        type='RandAugment',
+        policies=policies,
+        num_policies=2,
+        magnitude_level=12,
+        magnitude_std=-1)
+    pipeline = build_from_cfg(transform, PIPELINES)
+    # apply translate (magnitude=0.4) and invert
+    results = pipeline(results)
+    img_augmented = np.array(
+        [[127, 127, 254, 253], [127, 127, 250, 249], [127, 127, 246, 245]],
+        dtype=np.uint8)
+    img_augmented = np.stack([img_augmented, img_augmented, img_augmented],
+                             axis=-1)
+    np.testing.assert_array_equal(results['img'], img_augmented)
 
 
 def test_shear():


### PR DESCRIPTION
`magnitude_std` will introduce some randomness to policies, modified by https://github.com/rwightman/pytorch-image-models
Here is the instrument in the original repo:
```
        # If magnitude_std is > 0, we introduce some randomness
        # in the usually fixed policy and sample magnitude from a normal distribution
        # with mean `magnitude` and std-dev of `magnitude_std`.
        # NOTE This is my own hack, being tested, not in papers or reference impls.
        # If magnitude_std is inf, we sample magnitude from a uniform distribution
```