### PR TITLE
Check if specified tmpdir exists when inference.

### DIFF
--- a/mmcls/apis/test.py
+++ b/mmcls/apis/test.py
@@ -133,6 +133,10 @@ def collect_results_cpu(result_part, size, tmpdir=None):
         dist.broadcast(dir_tensor, 0)
         tmpdir = dir_tensor.cpu().numpy().tobytes().decode().rstrip()
     else:
+        if osp.exist(tmpdir):
+            raise OSError((f'The tmpdir {tmpdir} already exists.',
+                           ' Since tmpdir will be deleted after testing,',
+                           ' please make sure you specify an empty one.'))
         mmcv.mkdir_or_exist(tmpdir)
     # dump the part result to the dir
     mmcv.dump(result_part, osp.join(tmpdir, f'part_{rank}.pkl'))


### PR DESCRIPTION
This PR fixed potential fatal errors when using mmclassification for testing/inference.
Current testing code will create a user-specified temp directory while deleting it after use.
The function does not stop if the temp directory exists and may accidentally delete original data in the folder.
This PR fixed it.