### PR TITLE
[Fix]Fix MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
 include mmcls/model_zoo.yml
-include mmcls/configs/*/*.py
-include mmcls/configs/*/*.yml
-include mmcls/tools/*.py
-include mmcls/tools/*.sh
-include mmcls/tools/*/*.py
+recursive-include mmcls/configs *.py *.yml
+recursive-include mmcls/tools *.sh *.py


### PR DESCRIPTION
Hi,
Previously, the MANIFEST.in fails to include mmcls/configs/\_base\_/\*/\*.py. This pull request fixes the issue. Thank you.