### PR TITLE
Simplify testing logits and fix test typo

### DIFF
--- a/mmcls/apis/test.py
+++ b/mmcls/apis/test.py
@@ -134,11 +134,12 @@ def collect_results_cpu(result_part, size, tmpdir=None):
         dist.broadcast(dir_tensor, 0)
         tmpdir = dir_tensor.cpu().numpy().tobytes().decode().rstrip()
     else:
-        if osp.exist(tmpdir):
-            raise OSError((f'The tmpdir {tmpdir} already exists.',
-                           ' Since tmpdir will be deleted after testing,',
-                           ' please make sure you specify an empty one.'))
-        mmcv.mkdir_or_exist(tmpdir)
+        if rank == 0:
+            if osp.exists(tmpdir):
+                raise OSError((f'The tmpdir {tmpdir} already exists.',
+                               ' Since tmpdir will be deleted after testing,',
+                               ' please make sure you specify an empty one.'))
+            mmcv.mkdir_or_exist(tmpdir)
     # dump the part result to the dir
     mmcv.dump(result_part, osp.join(tmpdir, f'part_{rank}.pkl'))
     dist.barrier()


### PR DESCRIPTION
This PR fixes:
1. Simplify testing logits by merging the case when tmpdir=None and specify tmpdir
2. Fix testing typo