### PR TITLE
[Bug] Download dataset only on rank 0

### DIFF
--- a/mmcls/datasets/cifar.py
+++ b/mmcls/datasets/cifar.py
@@ -42,7 +42,7 @@ class CIFAR10(BaseDataset):
 
     def load_annotations(self):
 
-        rank, _ = get_dist_info()
+        rank, world_size = get_dist_info()
 
         if rank == 0 and not self._check_integrity():
             download_and_extract_archive(
@@ -51,9 +51,10 @@ class CIFAR10(BaseDataset):
                 filename=self.filename,
                 md5=self.tgz_md5)
 
-        dist.barrier()
-        assert self._check_integrity(), \
-            f'Please download the dataset manually through {self.url}.'
+        if world_size > 1:
+            dist.barrier()
+            assert self._check_integrity(), \
+                f'Please download the dataset manually through {self.url}.'
 
         if not self.test_mode:
             downloaded_list = self.train_list

--- a/mmcls/datasets/cifar.py
+++ b/mmcls/datasets/cifar.py
@@ -54,6 +54,7 @@ class CIFAR10(BaseDataset):
         if world_size > 1:
             dist.barrier()
             assert self._check_integrity(), \
+                'Shared storage seems unavailable. ' \
                 f'Please download the dataset manually through {self.url}.'
 
         if not self.test_mode:

--- a/mmcls/datasets/cifar.py
+++ b/mmcls/datasets/cifar.py
@@ -42,7 +42,7 @@ class CIFAR10(BaseDataset):
 
     def load_annotations(self):
 
-        rank, _ = get_dist_info
+        rank, _ = get_dist_info()
 
         if rank == 0 and not self._check_integrity():
             download_and_extract_archive(
@@ -52,7 +52,8 @@ class CIFAR10(BaseDataset):
                 md5=self.tgz_md5)
 
         dist.barrier()
-        assert self._check_integrity(), 'Please download the dataset manually.'
+        assert self._check_integrity(), \
+            f'Please download the dataset manually through {self.url}.'
 
         if not self.test_mode:
             downloaded_list = self.train_list

--- a/mmcls/datasets/mnist.py
+++ b/mmcls/datasets/mnist.py
@@ -4,6 +4,8 @@ import os.path as osp
 
 import numpy as np
 import torch
+import torch.distributed as dist
+from mmcv.runner import master_only
 
 from .base_dataset import BaseDataset
 from .builder import DATASETS
@@ -49,6 +51,11 @@ class MNIST(BaseDataset):
                 train_label_file) or not osp.exists(
                     test_image_file) or not osp.exists(test_label_file):
             self.download()
+        dist.barrier()
+        assert osp.exists(train_image_file) and osp.exists(
+            train_label_file) and osp.exists(
+                test_image_file) and osp.exists(test_label_file), \
+            f'Please download dataset manually through {self.resource_prefix}.'
 
         train_set = (read_image_file(train_image_file),
                      read_label_file(train_label_file))
@@ -67,6 +74,7 @@ class MNIST(BaseDataset):
             data_infos.append(info)
         return data_infos
 
+    @master_only
     def download(self):
         os.makedirs(self.data_prefix, exist_ok=True)
 

--- a/mmcls/datasets/mnist.py
+++ b/mmcls/datasets/mnist.py
@@ -58,8 +58,8 @@ class MNIST(BaseDataset):
             assert osp.exists(train_image_file) and osp.exists(
                 train_label_file) and osp.exists(
                     test_image_file) and osp.exists(test_label_file), \
-                f'Please download dataset manually ' \
-                f'through {self.resource_prefix}.'
+                'Shared storage seems unavailable. Please download dataset ' \
+                f'manually through {self.resource_prefix}.'
 
         train_set = (read_image_file(train_image_file),
                      read_label_file(train_label_file))


### PR DESCRIPTION
Hi,

Previously, when cifar/mnist dataset is not found locally, the dataset is downloaded on all ranks. However this not only wastes bandwidth but also causes error when the storage is shared among ranks. And this pull request fixes this issue by:
1. Download the dataset only on rank 0.
2. If shared storage is not avaliable, we raise an error and suggest that user shall download the dataset manually.

