### PR TITLE
Refactor LabelSmoothLoss

### DIFF
--- a/mmcls/models/losses/label_smooth_loss.py
+++ b/mmcls/models/losses/label_smooth_loss.py
@@ -36,7 +36,8 @@ class LabelSmoothLoss(nn.Module):
         .. math::
         (1-\epsilon)\delta_{k, y} + \frac{\epsilon}{K}
 
-        where epsilon is the `label_smooth_val` and the K is num_classes.
+        where epsilon is the `label_smooth_val`, K is the num_classes and
+        delta(k,y) is Dirac delta, which equals 1 for k=y and 0 otherwise.
 
         if the mode is "classy_vision", this will use the same label smooth
         method as the facebookresearch/ClassyVision repo as:

--- a/mmcls/models/losses/label_smooth_loss.py
+++ b/mmcls/models/losses/label_smooth_loss.py
@@ -1,4 +1,7 @@
-import numpy as np
+import warnings
+
+import torch
+import torch.nn as nn
 
 from ..builder import LOSSES
 from .cross_entropy_loss import CrossEntropyLoss
@@ -6,60 +9,112 @@ from .utils import convert_to_one_hot
 
 
 @LOSSES.register_module()
-class LabelSmoothLoss(CrossEntropyLoss):
-    """Intializer for the label smoothed cross entropy loss.
+class LabelSmoothLoss(nn.Module):
+    r"""Intializer for the label smoothed cross entropy loss.
+    Refers to `Rethinking the Inception Architecture for Computer Vision` -
+        https://arxiv.org/abs/1512.00567
 
     This decreases gap between output scores and encourages generalization.
     Labels provided to forward can be one-hot like vectors (NxC) or class
     indices (Nx1).
-    This normalizes the labels to a sum of 1 based on the total count of
-    positive targets for a given sample before applying label smoothing.
+    And this accepts linear combination of one-hot like labels from mixup or
+    cutmix except multi-label task.
 
     Args:
-        label_smooth_val (float): Value to be added to each target entry
+        label_smooth_val (float): The degree of label smoothing.
         num_classes (int, optional): Number of classes. Defaults to None.
+        mode (str): Refers to notes, Options are 'original', 'classy_vision',
+            'multi_label'. Defaults to 'classy_vision'
         reduction (str): The method used to reduce the loss.
             Options are "none", "mean" and "sum". Defaults to 'mean'.
         loss_weight (float):  Weight of the loss. Defaults to 1.0.
+
+    Notes:
+        if the mode is "original", this will use the same label smooth method
+        as the original paper as:
+
+        .. math::
+        (1-\epsilon)\delta_{k, y} + \frac{\epsilon}{K}
+
+        where epsilon is the `label_smooth_val` and the K is num_classes.
+
+        if the mode is "classy_vision", this will use the same label smooth
+        method as the facebookresearch/ClassyVision repo as:
+
+        .. math::
+        \frac{\delta_{k, y} + \epsilon/K}{1+\epsilon}
+
+        if the mode is "multi_label", this will accept labels from multi-label
+        task and smoothing them as:
+
+        .. math::
+        (1-2\epsilon)\delta_{k, y} + \epsilon
     """
 
     def __init__(self,
                  label_smooth_val,
                  num_classes=None,
+                 mode=None,
                  reduction='mean',
                  loss_weight=1.0):
-        super(LabelSmoothLoss, self).__init__(
-            use_sigmoid=False,
-            use_soft=True,
-            reduction=reduction,
-            loss_weight=loss_weight)
-        self._label_smooth_val = label_smooth_val
+        super().__init__()
         self.num_classes = num_classes
-        self._eps = np.finfo(np.float32).eps
+        self.loss_weight = loss_weight
+
+        assert (isinstance(label_smooth_val, float)
+                and 0 <= label_smooth_val < 1), \
+            f'LabelSmoothLoss accepts a float label_smooth_val ' \
+            f'over [0, 1), but gets {label_smooth_val}'
+        self.label_smooth_val = label_smooth_val
+
+        accept_reduction = {'none', 'mean', 'sum'}
+        assert reduction in accept_reduction, \
+            f'LabelSmoothLoss supports reduction {accept_reduction}, ' \
+            f'but gets {mode}.'
+        self.reduction = reduction
+
+        if mode is None:
+            warnings.warn(
+                'LabelSmoothLoss mode is not set, use "classy_vision" '
+                'by default. The default value will be changed to '
+                '"original" recently. Please set mode manually if want '
+                'to keep "classy_vision".', UserWarning)
+            mode = 'classy_vision'
+
+        accept_mode = {'original', 'classy_vision', 'multi_label'}
+        assert mode in accept_mode, \
+            f'LabelSmoothLoss supports mode {accept_mode}, but gets {mode}.'
+        self.mode = mode
+
+        self._eps = label_smooth_val
+        if mode == 'classy_vision':
+            self._eps = label_smooth_val / (1 + label_smooth_val)
+        if mode == 'multi_label':
+            self.ce = CrossEntropyLoss(use_sigmoid=True)
+            self.smooth_label = self.multilabel_smooth_label
+        else:
+            self.ce = CrossEntropyLoss(use_soft=True)
+            self.smooth_label = self.original_smooth_label
 
     def generate_one_hot_like_label(self, label):
         """This function takes one-hot or index label vectors and computes one-
         hot like label vectors (float)"""
-        label_shape_list = list(label.size())
         # check if targets are inputted as class integers
-        if len(label_shape_list) == 1 or (len(label_shape_list) == 2
-                                          and label_shape_list[1] == 1):
+        if label.dim() == 1 or (label.dim() == 2 and label.shape[1] == 1):
             label = convert_to_one_hot(label.view(-1, 1), self.num_classes)
         return label.float()
 
-    def smooth_label(self, one_hot_like_label):
-        """This function takes one-hot like target vectors and computes
-        smoothed target vectors (normalized) according to the loss's smoothing
-        parameter."""
+    def original_smooth_label(self, one_hot_like_label):
         assert self.num_classes > 0
-        one_hot_like_label /= self._eps + one_hot_like_label.sum(
-            dim=1, keepdim=True)
-        smoothed_targets = one_hot_like_label + (
-            self._label_smooth_val / self.num_classes)
-        smoothed_targets /= self._eps + smoothed_targets.sum(
-            dim=1, keepdim=True)
+        smooth_label = one_hot_like_label * (1 - self._eps)
+        smooth_label += self._eps / self.num_classes
+        return smooth_label
 
-        return smoothed_targets
+    def multilabel_smooth_label(self, one_hot_like_label):
+        assert self.num_classes > 0
+        smooth_label = torch.full_like(one_hot_like_label, self._eps)
+        smooth_label.masked_fill_(one_hot_like_label > 0, 1 - self._eps)
+        return smooth_label
 
     def forward(self,
                 cls_score,
@@ -75,15 +130,15 @@ class LabelSmoothLoss(CrossEntropyLoss):
                 f'cls_score.shape[1]: {cls_score.shape[1]}'
         else:
             self.num_classes = cls_score.shape[1]
+
         one_hot_like_label = self.generate_one_hot_like_label(label=label)
-        assert (
-            one_hot_like_label.shape == cls_score.shape
-        ), f'LabelSmoothingCrossEntropyLoss requires output and target ' \
-           f'to be same shape, but got output.shape: {cls_score.shape}' \
-           f'and target.shape: {one_hot_like_label.shape}'
-        smoothed_label = self.smooth_label(
-            one_hot_like_label=one_hot_like_label)
-        return super(LabelSmoothLoss, self).forward(
+        assert one_hot_like_label.shape == cls_score.shape, \
+            f'LabelSmoothLoss requires output and target ' \
+            f'to be same shape, but got output.shape: {cls_score.shape} ' \
+            f'and target.shape: {one_hot_like_label.shape}'
+
+        smoothed_label = self.smooth_label(one_hot_like_label)
+        return self.ce.forward(
             cls_score,
             smoothed_label,
             weight=weight,


### PR DESCRIPTION
Now, label smooth loss accepts a parameter `mode`. It can be one of "original", "classy_vision" and "multi_label" and use the corresponding method to calculate smoothing labels.
