### PR TITLE
[Bug] Missing test data when num_imgs can not be evenly divided by num_gpus

### DIFF
--- a/mmcls/apis/test.py
+++ b/mmcls/apis/test.py
@@ -152,10 +152,7 @@ def collect_results_cpu(result_part, size, tmpdir=None):
         for i in range(world_size):
             part_file = osp.join(tmpdir, f'part_{i}.pkl')
             part_result = mmcv.load(part_file)
-            # When data is severely insufficient, an empty part_result
-            # on a certain gpu could makes the overall outputs empty.
-            if part_result:
-                part_list.append(part_result)
+            part_list.append(part_result)
         # sort the results
         ordered_results = []
         for res in zip(*part_list):
@@ -190,10 +187,7 @@ def collect_results_gpu(result_part, size):
         part_list = []
         for recv, shape in zip(part_recv_list, shape_list):
             part_result = pickle.loads(recv[:shape[0]].cpu().numpy().tobytes())
-            # When data is severely insufficient, an empty part_result
-            # on a certain gpu could makes the overall outputs empty.
-            if part_result:
-                part_list.append(part_result)
+            part_list.append(part_result)
         # sort the results
         ordered_results = []
         for res in zip(*part_list):

--- a/tools/test.py
+++ b/tools/test.py
@@ -96,13 +96,14 @@ def main():
 
     # build the dataloader
     dataset = build_dataset(cfg.data.test)
+    # the extra round_up data will be removed during gpu/cpu collect
     data_loader = build_dataloader(
         dataset,
         samples_per_gpu=cfg.data.samples_per_gpu,
         workers_per_gpu=cfg.data.workers_per_gpu,
         dist=distributed,
         shuffle=False,
-        round_up=False)
+        round_up=True)
 
     # build the model and load checkpoint
     model = build_classifier(cfg.model)


### PR DESCRIPTION
Hi,

In this pull request, a bug is fixed. 

Previously, if we do not round up the data, when num_imgs can not be evenly divided by num_gpus, results for some imgs might be accidentally loss and finally cause assertion error when we check `len(gt_labels) == len(results)`. In this way, previous check of whether `part_result` is unnecessary since all rank shall have the same length of `part_result`.

Pls kindly take a look. Thank u.