### PR TITLE
[Fix] Build compatible with low pytorch versions

### DIFF
--- a/docs/tutorials/pytorch2torchscript.md
+++ b/docs/tutorials/pytorch2torchscript.md
@@ -5,7 +5,7 @@
 - [Tutorial 5: Pytorch to TorchScript (Experimental)](#tutorial-5-pytorch-to-torchscript-experimental)
   - [How to convert models from Pytorch to TorchScript](#how-to-convert-models-from-pytorch-to-torchscript)
     - [Usage](#usage)
-    - [Description of all arguments:](#description-of-all-arguments)
+    - [Description of all arguments](#description-of-all-arguments)
   - [Reminders](#reminders)
   - [FAQs](#faqs)
 
@@ -24,7 +24,7 @@ python tools/deployment/pytorch2torchscript.py \
     --verify \
 ```
 
-### Description of all arguments:
+### Description of all arguments
 
 - `config` : The path of a model config file.
 - `--checkpoint` : The path of a model checkpoint file.

--- a/docs/tutorials/pytorch2torchscript.md
+++ b/docs/tutorials/pytorch2torchscript.md
@@ -48,7 +48,7 @@ Notes:
 
 ## Reminders
 
-- For torch.jit.is_tracing() is only supported after v1.6. For users with pytorch 1.3-1.5, we suggest early returning tensors manually.
+- For torch.jit.is_tracing() is only supported after v1.6. For users with pytorch v1.3-v1.5, we suggest early returning tensors manually.
 - If you meet any problem with the models in this repo, please create an issue and it would be taken care of soon.
 
 ## FAQs

--- a/docs/tutorials/pytorch2torchscript.md
+++ b/docs/tutorials/pytorch2torchscript.md
@@ -5,7 +5,7 @@
 - [Tutorial 5: Pytorch to TorchScript (Experimental)](#tutorial-5-pytorch-to-torchscript-experimental)
   - [How to convert models from Pytorch to TorchScript](#how-to-convert-models-from-pytorch-to-torchscript)
     - [Usage](#usage)
-    - [Description of all arguments](#description-of-all-arguments)
+    - [Description of all arguments:](#description-of-all-arguments)
   - [Reminders](#reminders)
   - [FAQs](#faqs)
 
@@ -48,6 +48,7 @@ Notes:
 
 ## Reminders
 
+- For torch.jit.is_tracing() is only supported after v1.6. For users with pytorch 1.3-1.5, we suggest early returning tensors manually.
 - If you meet any problem with the models in this repo, please create an issue and it would be taken care of soon.
 
 ## FAQs

--- a/mmcls/models/heads/cls_head.py
+++ b/mmcls/models/heads/cls_head.py
@@ -62,7 +62,9 @@ class ClsHead(BaseHead):
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
-        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+
+        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or is_tracing:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/cls_head.py
+++ b/mmcls/models/heads/cls_head.py
@@ -63,8 +63,8 @@ class ClsHead(BaseHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
 
-        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
-        if torch.onnx.is_in_onnx_export() or is_tracing:
+        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/linear_head.py
+++ b/mmcls/models/heads/linear_head.py
@@ -44,8 +44,8 @@ class LinearClsHead(ClsHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
 
-        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
-        if torch.onnx.is_in_onnx_export() or is_tracing:
+        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/linear_head.py
+++ b/mmcls/models/heads/linear_head.py
@@ -43,7 +43,9 @@ class LinearClsHead(ClsHead):
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
-        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+
+        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or is_tracing:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/multi_label_head.py
+++ b/mmcls/models/heads/multi_label_head.py
@@ -47,7 +47,9 @@ class MultiLabelClsHead(BaseHead):
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.sigmoid(cls_score) if cls_score is not None else None
-        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+
+        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or is_tracing:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/multi_label_head.py
+++ b/mmcls/models/heads/multi_label_head.py
@@ -48,8 +48,8 @@ class MultiLabelClsHead(BaseHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.sigmoid(cls_score) if cls_score is not None else None
 
-        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
-        if torch.onnx.is_in_onnx_export() or is_tracing:
+        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/multi_label_linear_head.py
+++ b/mmcls/models/heads/multi_label_linear_head.py
@@ -57,8 +57,8 @@ class MultiLabelLinearClsHead(MultiLabelClsHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.sigmoid(cls_score) if cls_score is not None else None
 
-        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
-        if torch.onnx.is_in_onnx_export() or is_tracing:
+        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/multi_label_linear_head.py
+++ b/mmcls/models/heads/multi_label_linear_head.py
@@ -56,7 +56,9 @@ class MultiLabelLinearClsHead(MultiLabelClsHead):
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.sigmoid(cls_score) if cls_score is not None else None
-        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+
+        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or is_tracing:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/vision_transformer_head.py
+++ b/mmcls/models/heads/vision_transformer_head.py
@@ -69,8 +69,8 @@ class VisionTransformerClsHead(ClsHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
 
-        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
-        if torch.onnx.is_in_onnx_export() or is_tracing:
+        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/mmcls/models/heads/vision_transformer_head.py
+++ b/mmcls/models/heads/vision_transformer_head.py
@@ -68,7 +68,9 @@ class VisionTransformerClsHead(ClsHead):
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
-        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+
+        is_tracing = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        if torch.onnx.is_in_onnx_export() or is_tracing:
             return pred
         pred = list(pred.detach().cpu().numpy())
         return pred

--- a/tools/deployment/pytorch2torchscript.py
+++ b/tools/deployment/pytorch2torchscript.py
@@ -1,5 +1,5 @@
-import os
 import argparse
+import os
 import os.path as osp
 from functools import partial
 


### PR DESCRIPTION
Hi, this is a PR for mim installing mmclassification with pytorch v1.3-v1.5.

torch.jit.is_tracing() is supported after pytorch v1.6. For pytorch v1.3-v1.5, mim installing mmclassification will fail like [this](https://github.com/open-mmlab/mim/pull/39/checks?check_run_id=2811922234#step:9:242).