### PR TITLE
fix a bug when samples_per_gpu==1

### DIFF
--- a/mmcls/models/classifiers/image.py
+++ b/mmcls/models/classifiers/image.py
@@ -78,4 +78,7 @@ class ImageClassifier(BaseClassifier):
     def simple_test(self, img, img_metas):
         """Test without augmentation."""
         x = self.extract_feat(img)
+        x_dims = len(x.shape)
+        if x_dims == 1:
+            x.unsqueeze_(0)
         return self.head.simple_test(x)


### PR DESCRIPTION
when I define 
```
   samples_per_gpu=1,
   workers_per_gpu=0,
```
in configs/lenet/lenet5_mnist.py.
An  error  occurred:
>   ..............
>   File "/home/n/Github/mmclassification0110/mmclassification/mmcls/models/classifiers/base.py", line 73, in forward_test
>     return self.simple_test(imgs[0], **kwargs)
>   File "/home/n/Github/mmclassification0110/mmclassification/mmcls/models/classifiers/**image.py**", line 81, in simple_test
>     return self.head.simple_test(x)
>   File "/home/n/Github/mmclassification0110/mmclassification/mmcls/models/heads/cls_head.py", line 64, in simple_test
>     pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
>   File "/home/n/anaconda3/envs/pytorch130/lib/python3.7/site-packages/torch/nn/functional.py", line 1231, in softmax
>     ret = input.softmax(dim)
> IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)

So, I added some code in **image.py** to avoid this error.Although,` samples_per_gpu=1`  is rare.
