### PR TITLE
[Docs] Add API Reference in the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,66 @@
+API Reference
+=============
+
+mmcls.apis
+-------------
+.. automodule:: mmcls.apis
+    :members:
+
+mmcls.core
+-------------
+
+evaluation
+^^^^^^^^^^
+.. automodule:: mmcls.core.evaluation
+    :members:
+
+mmcls.models
+---------------
+
+models
+^^^^^^
+.. automodule:: mmcls.models
+    :members:
+
+classifiers
+^^^^^^^^^^^
+.. automodule:: mmcls.models.classifiers
+    :members:
+
+backbones
+^^^^^^^^^^
+.. automodule:: mmcls.models.backbones
+    :members:
+
+necks
+^^^^^^
+.. automodule:: mmcls.models.necks
+    :members:
+
+losses
+^^^^^^
+.. automodule:: mmcls.models.losses
+    :members:
+
+utils
+^^^^^^
+.. automodule:: mmcls.models.utils
+    :members:
+
+mmcls.datasets
+-----------------
+
+datasets
+^^^^^^^^
+.. automodule:: mmcls.datasets
+    :members:
+
+pipelines
+^^^^^^^^^
+.. automodule:: mmcls.datasets.pipelines
+    :members:
+
+mmcls.utils
+--------------
+.. automodule:: mmcls.utils
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
     'sphinx_markdown_tables',
 ]
 
-autodoc_mock_imports = ['mmcls.version']
+autodoc_mock_imports = ['matplotlib', 'mmcls.version', 'mmcv.ops']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -70,7 +70,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 master_doc = 'index'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to MMClassification's documentation!
-==========================================
+============================================
 
 You can switch between Chinese and English documents in the lower-left corner of the layout.
 
@@ -38,6 +38,12 @@ You can switch between Chinese and English documents in the lower-left corner of
    tools/onnx2tensorrt.md
    tools/pytorch2torchscript.md
    tools/model_serving.md
+
+
+.. toctree::
+   :caption: API Reference
+
+   api.rst
 
 
 .. toctree::

--- a/docs/tutorials/new_dataset.md
+++ b/docs/tutorials/new_dataset.md
@@ -138,4 +138,4 @@ dataset_A_train = dict(
     )
 ```
 
-You may refer to [source code](../../mmcls/datasets/dataset_wrappers.py) for details.
+You may refer to [source code](https://github.com/open-mmlab/mmclassification/tree/master/mmcls/datasets/dataset_wrappers.py) for details.

--- a/docs_zh-CN/api.rst
+++ b/docs_zh-CN/api.rst
@@ -1,0 +1,66 @@
+API Reference
+=============
+
+mmcls.apis
+-------------
+.. automodule:: mmcls.apis
+    :members:
+
+mmcls.core
+-------------
+
+evaluation
+^^^^^^^^^^
+.. automodule:: mmcls.core.evaluation
+    :members:
+
+mmcls.models
+---------------
+
+models
+^^^^^^
+.. automodule:: mmcls.models
+    :members:
+
+classifiers
+^^^^^^^^^^^
+.. automodule:: mmcls.models.classifiers
+    :members:
+
+backbones
+^^^^^^^^^^
+.. automodule:: mmcls.models.backbones
+    :members:
+
+necks
+^^^^^^
+.. automodule:: mmcls.models.necks
+    :members:
+
+losses
+^^^^^^
+.. automodule:: mmcls.models.losses
+    :members:
+
+utils
+^^^^^^
+.. automodule:: mmcls.models.utils
+    :members:
+
+mmcls.datasets
+-----------------
+
+datasets
+^^^^^^^^
+.. automodule:: mmcls.datasets
+    :members:
+
+pipelines
+^^^^^^^^^
+.. automodule:: mmcls.datasets.pipelines
+    :members:
+
+mmcls.utils
+--------------
+.. automodule:: mmcls.utils
+    :members:

--- a/docs_zh-CN/conf.py
+++ b/docs_zh-CN/conf.py
@@ -46,7 +46,7 @@ extensions = [
     'sphinx_markdown_tables',
 ]
 
-autodoc_mock_imports = ['mmcls.version']
+autodoc_mock_imports = ['matplotlib', 'mmcls.version', 'mmcv.ops']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -70,7 +70,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 language = 'zh_CN'
 

--- a/docs_zh-CN/index.rst
+++ b/docs_zh-CN/index.rst
@@ -41,6 +41,12 @@ You can switch between Chinese and English documents in the lower-left corner of
 
 
 .. toctree::
+   :caption: API 参考文档
+
+   api.rst
+
+
+.. toctree::
    :caption: 语言切换
 
    switch_language.md

--- a/docs_zh-CN/tutorials/finetune.md
+++ b/docs_zh-CN/tutorials/finetune.md
@@ -2,7 +2,7 @@
 
 已经证明，在 ImageNet 数据集上预先训练的分类模型对于其他数据集和其他下游任务有很好的效果。
 
-该教程提供了如何将 [Model Zoo](../model_zoo.md) 中提供的预训练模型用于其他数据集，已获得更好的效果。
+该教程提供了如何将 [Model Zoo](https://github.com/open-mmlab/mmclassification/blob/master/docs/model_zoo.md) 中提供的预训练模型用于其他数据集，已获得更好的效果。
 
 在新数据集上微调模型分为两步：
 

--- a/docs_zh-CN/tutorials/new_dataset.md
+++ b/docs_zh-CN/tutorials/new_dataset.md
@@ -137,4 +137,4 @@ dataset_A_train = dict(
     )
 ```
 
-更加具体的细节，请参考 [源代码](../../mmcls/datasets/dataset_wrappers.py)。
+更加具体的细节，请参考 [源代码](https://github.com/open-mmlab/mmclassification/tree/master/mmcls/datasets/dataset_wrappers.py)。

--- a/mmcls/core/evaluation/eval_metrics.py
+++ b/mmcls/core/evaluation/eval_metrics.py
@@ -11,8 +11,8 @@ def calculate_confusion_matrix(pred, target):
             shape (N, 1) or (N,).
 
     Returns:
-        torch.Tensor: Confusion matrix with shape (C, C), where C is the number
-             of classes.
+        torch.Tensor: Confusion matrix
+            The shape is (C, C), where C is the number of classes.
     """
 
     if isinstance(pred, np.ndarray):
@@ -53,13 +53,17 @@ def precision_recall_f1(pred, target, average_mode='macro', thrs=None):
             the thresholds are considered negative. Default to None.
 
     Returns:
-        float | np.array | list[float | np.array]: Precision, recall, f1 score.
-            If the ``average_mode`` is set to macro, np.array is used in favor
-            of float to give class-wise results. If the ``average_mode`` is set
-             to none, float is used to return a single value.
-            If ``thrs`` is a single float or None, the function will return
-            float or np.array. If ``thrs`` is a tuple, the function will return
-             a list containing metrics for each ``thrs`` condition.
+        tuple: tuple containing precision, recall, f1 score.
+
+            The type of precision, recall, f1 score is one of the following:
+
+        +----------------------------+--------------------+-------------------+
+        | Args                       | ``thrs`` is number | ``thrs`` is tuple |
+        +============================+====================+===================+
+        | ``average_mode`` = "macro" | float              | list[float]       |
+        +----------------------------+--------------------+-------------------+
+        | ``average_mode`` = "none"  | np.array           | list[np.array]    |
+        +----------------------------+--------------------+-------------------+
     """
 
     allowed_average_mode = ['macro', 'none']
@@ -136,12 +140,14 @@ def precision(pred, target, average_mode='macro', thrs=None):
 
     Returns:
          float | np.array | list[float | np.array]: Precision.
-            If the ``average_mode`` is set to macro, np.array is used in favor
-            of float to give class-wise results. If the ``average_mode`` is set
-             to none, float is used to return a single value.
-            If ``thrs`` is a single float or None, the function will return
-            float or np.array. If ``thrs`` is a tuple, the function will return
-             a list containing metrics for each ``thrs`` condition.
+
+        +----------------------------+--------------------+-------------------+
+        | Args                       | ``thrs`` is number | ``thrs`` is tuple |
+        +============================+====================+===================+
+        | ``average_mode`` = "macro" | float              | list[float]       |
+        +----------------------------+--------------------+-------------------+
+        | ``average_mode`` = "none"  | np.array           | list[np.array]    |
+        +----------------------------+--------------------+-------------------+
     """
     precisions, _, _ = precision_recall_f1(pred, target, average_mode, thrs)
     return precisions
@@ -164,12 +170,14 @@ def recall(pred, target, average_mode='macro', thrs=None):
 
     Returns:
          float | np.array | list[float | np.array]: Recall.
-            If the ``average_mode`` is set to macro, np.array is used in favor
-            of float to give class-wise results. If the ``average_mode`` is set
-             to none, float is used to return a single value.
-            If ``thrs`` is a single float or None, the function will return
-            float or np.array. If ``thrs`` is a tuple, the function will return
-             a list containing metrics for each ``thrs`` condition.
+
+        +----------------------------+--------------------+-------------------+
+        | Args                       | ``thrs`` is number | ``thrs`` is tuple |
+        +============================+====================+===================+
+        | ``average_mode`` = "macro" | float              | list[float]       |
+        +----------------------------+--------------------+-------------------+
+        | ``average_mode`` = "none"  | np.array           | list[np.array]    |
+        +----------------------------+--------------------+-------------------+
     """
     _, recalls, _ = precision_recall_f1(pred, target, average_mode, thrs)
     return recalls
@@ -192,12 +200,14 @@ def f1_score(pred, target, average_mode='macro', thrs=None):
 
     Returns:
          float | np.array | list[float | np.array]: F1 score.
-            If the ``average_mode`` is set to macro, np.array is used in favor
-            of float to give class-wise results. If the ``average_mode`` is set
-             to none, float is used to return a single value.
-            If ``thrs`` is a single float or None, the function will return
-            float or np.array. If ``thrs`` is a tuple, the function will return
-             a list containing metrics for each ``thrs`` condition.
+
+        +----------------------------+--------------------+-------------------+
+        | Args                       | ``thrs`` is number | ``thrs`` is tuple |
+        +============================+====================+===================+
+        | ``average_mode`` = "macro" | float              | list[float]       |
+        +----------------------------+--------------------+-------------------+
+        | ``average_mode`` = "none"  | np.array           | list[np.array]    |
+        +----------------------------+--------------------+-------------------+
     """
     _, _, f1_scores = precision_recall_f1(pred, target, average_mode, thrs)
     return f1_scores
@@ -218,10 +228,12 @@ def support(pred, target, average_mode='macro'):
             Defaults to 'macro'.
 
     Returns:
-        float | np.array: Precision, recall, f1 score.
-            The function returns a single float if the average_mode is set to
-            macro, or a np.array with shape C if the average_mode is set to
-             none.
+        float | np.array: Support.
+
+            - If the ``average_mode`` is set to macro, the function returns
+              a single float.
+            - If the ``average_mode`` is set to none, the function returns
+              a np.array with shape C.
     """
     confusion_matrix = calculate_confusion_matrix(pred, target)
     with torch.no_grad():

--- a/mmcls/core/evaluation/mean_ap.py
+++ b/mmcls/core/evaluation/mean_ap.py
@@ -3,13 +3,13 @@ import torch
 
 
 def average_precision(pred, target):
-    """Calculate the average precision for a single class.
+    r"""Calculate the average precision for a single class.
 
     AP summarizes a precision-recall curve as the weighted mean of maximum
     precisions obtained for any r'>r, where r is the recall:
 
-    ..math::
-        \\text{AP} = \\sum_n (R_n - R_{n-1}) P_n
+    .. math::
+        \text{AP} = \sum_n (R_n - R_{n-1}) P_n
 
     Note that no approximation is involved since the curve is piecewise
     constant.

--- a/mmcls/datasets/base_dataset.py
+++ b/mmcls/datasets/base_dataset.py
@@ -89,6 +89,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
     @classmethod
     def get_classes(cls, classes=None):
         """Get class names of current dataset.
+
         Args:
             classes (Sequence[str] | str | None): If classes is None, use
                 default CLASSES defined by builtin dataset. If classes is a

--- a/mmcls/datasets/cifar.py
+++ b/mmcls/datasets/cifar.py
@@ -16,8 +16,8 @@ class CIFAR10(BaseDataset):
     """`CIFAR10 <https://www.cs.toronto.edu/~kriz/cifar.html>`_ Dataset.
 
     This implementation is modified from
-    https://github.com/pytorch/vision/blob/master/torchvision/datasets/cifar.py  # noqa: E501
-    """
+    https://github.com/pytorch/vision/blob/master/torchvision/datasets/cifar.py
+    """  # noqa: E501
 
     base_folder = 'cifar-10-batches-py'
     url = 'https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'

--- a/mmcls/datasets/dataset_wrappers.py
+++ b/mmcls/datasets/dataset_wrappers.py
@@ -71,28 +71,37 @@ class RepeatDataset(object):
 # Modified from https://github.com/facebookresearch/detectron2/blob/41d475b75a230221e21d9cac5d69655e3415e3a4/detectron2/data/samplers/distributed_sampler.py#L57 # noqa
 @DATASETS.register_module()
 class ClassBalancedDataset(object):
-    """A wrapper of repeated dataset with repeat factor.
+    r"""A wrapper of repeated dataset with repeat factor.
 
     Suitable for training on class imbalanced datasets like LVIS. Following
-    the sampling strategy in [1], in each epoch, an image may appear multiple
+    the sampling strategy in [#1]_, in each epoch, an image may appear multiple
     times based on its "repeat factor".
+
     The repeat factor for an image is a function of the frequency the rarest
     category labeled in that image. The "frequency of category c" in [0, 1]
     is defined by the fraction of images in the training set (without repeats)
     in which category c appears.
-    The dataset needs to instantiate :func:`self.get_cat_ids(idx)` to support
+
+    The dataset needs to implement :func:`self.get_cat_ids` to support
     ClassBalancedDataset.
+
     The repeat factor is computed as followed.
-    1. For each category c, compute the fraction # of images
-        that contain it: f(c)
-    2. For each category c, compute the category-level repeat factor:
-        r(c) = max(1, sqrt(t/f(c)))
-    3. For each image I and its labels L(I), compute the image-level repeat
-    factor:
-        r(I) = max_{c in L(I)} r(c)
+
+    1. For each category c, compute the fraction :math:`f(c)` of images that
+       contain it.
+    2. For each category c, compute the category-level repeat factor
+
+        .. math::
+            r(c) = \max(1, \sqrt{\frac{t}{f(c)}})
+
+    3. For each image I and its labels :math:`L(I)`, compute the image-level
+       repeat factor
+
+        .. math::
+            r(I) = \max_{c \in L(I)} r(c)
 
     References:
-        .. [1]  https://arxiv.org/pdf/1908.03195.pdf
+        .. [#1]  https://arxiv.org/pdf/1908.03195.pdf
 
     Args:
         dataset (:obj:`CustomDataset`): The dataset to be repeated.

--- a/mmcls/datasets/imagenet.py
+++ b/mmcls/datasets/imagenet.py
@@ -68,8 +68,8 @@ class ImageNet(BaseDataset):
     """`ImageNet <http://www.image-net.org>`_ Dataset.
 
     This implementation is modified from
-    https://github.com/pytorch/vision/blob/master/torchvision/datasets/imagenet.py  # noqa: E501
-    """
+    https://github.com/pytorch/vision/blob/master/torchvision/datasets/imagenet.py
+    """  # noqa: E501
 
     IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif')
     CLASSES = [

--- a/mmcls/datasets/mnist.py
+++ b/mmcls/datasets/mnist.py
@@ -17,8 +17,8 @@ class MNIST(BaseDataset):
     """`MNIST <http://yann.lecun.com/exdb/mnist/>`_ Dataset.
 
     This implementation is modified from
-    https://github.com/pytorch/vision/blob/master/torchvision/datasets/mnist.py  # noqa: E501
-    """
+    https://github.com/pytorch/vision/blob/master/torchvision/datasets/mnist.py
+    """  # noqa: E501
 
     resource_prefix = 'http://yann.lecun.com/exdb/mnist/'
     resources = {

--- a/mmcls/datasets/pipelines/auto_augment.py
+++ b/mmcls/datasets/pipelines/auto_augment.py
@@ -17,10 +17,10 @@ def random_negative(value, random_negative_prob):
 
 @PIPELINES.register_module()
 class AutoAugment(object):
-    """Auto augmentation. This data augmentation is proposed in `AutoAugment:
-    Learning Augmentation Policies from Data.
+    """Auto augmentation.
 
-    <https://arxiv.org/abs/1805.09501>`_.
+    This data augmentation is proposed in `AutoAugment: Learning Augmentation
+    Policies from Data <https://arxiv.org/abs/1805.09501>`_.
 
     Args:
         policies (list[list[dict]]): The policies of auto augmentation. Each
@@ -56,9 +56,10 @@ class AutoAugment(object):
 
 @PIPELINES.register_module()
 class RandAugment(object):
-    """Random augmentation. This data augmentation is proposed in `RandAugment:
-    Practical automated data augmentation with a reduced search space.
+    r"""Random augmentation.
 
+    This data augmentation is proposed in `RandAugment: Practical automated
+    data augmentation with a reduced search space
     <https://arxiv.org/abs/1909.13719>`_.
 
     Args:
@@ -78,19 +79,23 @@ class RandAugment(object):
         total_level (int | float): Total level for the magnitude. Defaults to
             30.
         magnitude_std (Number | str): Deviation of magnitude noise applied.
-            If positive number, magnitude is sampled from normal distribution
-                (mean=magnitude, std=magnitude_std).
-            If 0 or negative number, magnitude remains unchanged.
-            If str "inf", magnitude is sampled from uniform distribution
-                (range=[min, magnitude]).
+
+            - If positive number, magnitude is sampled from normal distribution
+              (mean=magnitude, std=magnitude_std).
+            - If 0 or negative number, magnitude remains unchanged.
+            - If str "inf", magnitude is sampled from uniform distribution
+              (range=[min, magnitude]).
 
     Note:
         `magnitude_std` will introduce some randomness to policy, modified by
-        https://github.com/rwightman/pytorch-image-models
+        https://github.com/rwightman/pytorch-image-models.
+
         When magnitude_std=0, we calculate the magnitude as follows:
 
         .. math::
-            magnitude = magnitude_level / total_level * (val2 - val1) + val1
+            \text{magnitude} = \frac{\text{magnitude_level}}
+            {\text{total_level}} \times (\text{val2} - \text{val1})
+            + \text{val1}
     """
 
     def __init__(self,
@@ -269,7 +274,7 @@ class Translate(object):
         magnitude (int | float): The magnitude used for translate. Note that
             the offset is calculated by magnitude * size in the corresponding
             direction. With a magnitude of 1, the whole image will be moved out
-             of the range.
+            of the range.
         pad_val (int, tuple[int]): Pixel pad_val value for constant fill. If a
             tuple of length 3, it is used to pad_val R, G, B channels
             respectively. Defaults to 128.
@@ -354,8 +359,8 @@ class Rotate(object):
         angle (float): The angle used for rotate. Positive values stand for
             clockwise rotation.
         center (tuple[float], optional): Center point (w, h) of the rotation in
-             the source image. If None, the center of the image will be used.
-            defaults to None.
+            the source image. If None, the center of the image will be used.
+            Defaults to None.
         scale (float): Isotropic scale factor. Defaults to 1.0.
         pad_val (int, tuple[int]): Pixel pad_val value for constant fill. If a
             tuple of length 3, it is used to pad_val R, G, B channels
@@ -692,7 +697,7 @@ class ColorTransform(object):
     Args:
         magnitude (int | float): The magnitude used for color transform. A
             positive magnitude would enhance the color and a negative magnitude
-             would make the image grayer. A magnitude=0 gives the origin img.
+            would make the image grayer. A magnitude=0 gives the origin img.
         prob (float): The probability for performing ColorTransform therefore
             should be in range [0, 1]. Defaults to 0.5.
         random_negative_prob (float): The probability that turns the magnitude

--- a/mmcls/datasets/pipelines/formating.py
+++ b/mmcls/datasets/pipelines/formating.py
@@ -115,13 +115,14 @@ class Collect(object):
         keys (Sequence[str]): Keys of results to be collected in ``data``.
         meta_keys (Sequence[str], optional): Meta keys to be converted to
             ``mmcv.DataContainer`` and collected in ``data[img_metas]``.
-            Default: ``('filename', 'ori_shape', 'img_shape', 'flip',
-            'flip_direction', 'img_norm_cfg')``
+            Default: ('filename', 'ori_shape', 'img_shape', 'flip',
+            'flip_direction', 'img_norm_cfg')
 
     Returns:
         dict: The result dict contains the following keys
-                - keys in``self.keys``
-                - ``img_metas`` if avaliable
+
+            - keys in ``self.keys``
+            - ``img_metas`` if avaliable
     """
 
     def __init__(self,

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -36,18 +36,19 @@ class RandomCrop(object):
         pad_val (Number | Sequence[Number]): Pixel pad_val value for constant
             fill. If a tuple of length 3, it is used to pad_val R, G, B
             channels respectively. Default: 0.
-        padding_mode (str): Type of padding. Should be: constant, edge,
-            reflect or symmetric. Default: constant.
-            -constant: Pads with a constant value, this value is specified
+        padding_mode (str): Type of padding. Defaults to "constant". Should
+            be one of the following:
+
+            - constant: Pads with a constant value, this value is specified \
                 with pad_val.
-            -edge: pads with the last value at the edge of the image.
-            -reflect: Pads with reflection of image without repeating the
-                last value on the edge. For example, padding [1, 2, 3, 4]
-                with 2 elements on both sides in reflect mode will result
+            - edge: pads with the last value at the edge of the image.
+            - reflect: Pads with reflection of image without repeating the \
+                last value on the edge. For example, padding [1, 2, 3, 4] \
+                with 2 elements on both sides in reflect mode will result \
                 in [3, 2, 1, 2, 3, 4, 3, 2].
-            -symmetric: Pads with reflection of image repeating the last
-                value on the edge. For example, padding [1, 2, 3, 4] with
-                2 elements on both sides in symmetric mode will result in
+            - symmetric: Pads with reflection of image repeating the last \
+                value on the edge. For example, padding [1, 2, 3, 4] with \
+                2 elements on both sides in symmetric mode will result in \
                 [2, 1, 1, 2, 3, 4, 4, 3].
     """
 
@@ -393,11 +394,12 @@ class RandomGrayscale(object):
             grayscale. Default: 0.1.
 
     Returns:
-        ndarray: Grayscale version of the input image with probability
-            gray_prob and unchanged with probability (1-gray_prob).
-            - If input image is 1 channel: grayscale version is 1 channel.
-            - If input image is 3 channel: grayscale version is 3 channel
-                with r == g == b.
+        ndarray: Image after randomly grayscale transform.
+
+    Notes:
+        - If input image is 1 channel: grayscale version is 1 channel.
+        - If input image is 3 channel: grayscale version is 3 channel
+          with r == g == b.
     """
 
     def __init__(self, gray_prob=0.1):
@@ -484,20 +486,24 @@ class RandomErasing(object):
             if float, it will be converted to (aspect_ratio, 1/aspect_ratio)
             Default: (3/10, 10/3)
         mode (str): Fill method in erased area, can be:
-            - 'const' (default): All pixels are assign with the same value.
-            - 'rand': each pixel is assigned with a random value in [0, 255]
+
+            - const (default): All pixels are assign with the same value.
+            - rand: each pixel is assigned with a random value in [0, 255]
+
         fill_color (sequence | Number): Base color filled in erased area.
-            Default: (128, 128, 128)
-        fill_std (sequence | Number, optional): If set and mode='rand', fill
-            erased area with random color from normal distribution
+            Defaults to (128, 128, 128).
+        fill_std (sequence | Number, optional): If set and ``mode`` is 'rand',
+            fill erased area with random color from normal distribution
             (mean=fill_color, std=fill_std); If not set, fill erased area with
-            random color from uniform distribution (0~255)
-            Default: None
+            random color from uniform distribution (0~255). Defaults to None.
 
     Note:
-        See https://arxiv.org/pdf/1708.04896.pdf
+        See `Random Erasing Data Augmentation
+        <https://arxiv.org/pdf/1708.04896.pdf>`_
+
         This paper provided 4 modes: RE-R, RE-M, RE-0, RE-255, and use RE-M as
-        default.
+        default. The config of these 4 modes are:
+
         - RE-R: RandomErasing(mode='rand')
         - RE-M: RandomErasing(mode='const', fill_color=(123.67, 116.3, 103.5))
         - RE-0: RandomErasing(mode='const', fill_color=0)
@@ -700,21 +706,23 @@ class CenterCrop(object):
             32.
         interpolation (str): Interpolation method, accepted values are
             'nearest', 'bilinear', 'bicubic', 'area', 'lanczos'. Only valid if
-             efficientnet style is True. Defaults to 'bilinear'.
+            ``efficientnet_style`` is True. Defaults to 'bilinear'.
         backend (str): The image resize backend type, accpeted values are
             `cv2` and `pillow`. Only valid if efficientnet style is True.
             Defaults to `cv2`.
 
 
     Notes:
-        If the image is smaller than the crop size, return the original image.
-        If efficientnet_style is set to False, the pipeline would be a simple
-        center crop using the crop_size.
-        If efficientnet_style is set to True, the pipeline will be to first to
-        perform the center crop with the crop_size_ as:
+        - If the image is smaller than the crop size, return the original
+          image.
+        - If efficientnet_style is set to False, the pipeline would be a simple
+          center crop using the crop_size.
+        - If efficientnet_style is set to True, the pipeline will be to first
+          to perform the center crop with the ``crop_size_`` as:
 
         .. math::
-        crop\_size\_ = crop\_size / (crop\_size + crop\_padding) * short\_edge
+            \text{crop_size_} = \frac{\text{crop_size}}{\text{crop_size} +
+            \text{crop_padding}} \times \text{short_edge}
 
         And then the pipeline resizes the img to the input crop size.
     """

--- a/mmcls/models/backbones/regnet.py
+++ b/mmcls/models/backbones/regnet.py
@@ -219,8 +219,9 @@ class RegNet(ResNet):
             divisor (int): The divisor of channels. Defaults to 8.
 
         Returns:
-            list, int: return a list of widths of each stage and the number of
-                stages
+            tuple: tuple containing:
+                - list: Widths of each stage.
+                - int: The number of stages.
         """
         assert width_slope >= 0
         assert initial_width > 0

--- a/mmcls/models/backbones/resnest.py
+++ b/mmcls/models/backbones/resnest.py
@@ -260,7 +260,7 @@ class Bottleneck(_Bottleneck):
 class ResNeSt(ResNetV1d):
     """ResNeSt backbone.
 
-    Please refer to the `paper <https://arxiv.org/pdf/2004.08955.pdf>`_ for
+    Please refer to the `paper <https://arxiv.org/pdf/2004.08955.pdf>`__ for
     details.
 
     Args:

--- a/mmcls/models/backbones/resnet.py
+++ b/mmcls/models/backbones/resnet.py
@@ -382,7 +382,7 @@ class ResLayer(nn.Sequential):
 class ResNet(BaseBackbone):
     """ResNet backbone.
 
-    Please refer to the `paper <https://arxiv.org/abs/1512.03385>`_ for
+    Please refer to the `paper <https://arxiv.org/abs/1512.03385>`__ for
     details.
 
     Args:
@@ -640,8 +640,9 @@ class ResNet(BaseBackbone):
 
 @BACKBONES.register_module()
 class ResNetV1d(ResNet):
-    """ResNetV1d variant described in `Bag of Tricks.
+    """ResNetV1d backbone.
 
+    This variant is described in `Bag of Tricks.
     <https://arxiv.org/pdf/1812.01187.pdf>`_.
 
     Compared with default ResNet(ResNetV1b), ResNetV1d replaces the 7x7 conv in

--- a/mmcls/models/backbones/resnext.py
+++ b/mmcls/models/backbones/resnext.py
@@ -89,7 +89,7 @@ class Bottleneck(_Bottleneck):
 class ResNeXt(ResNet):
     """ResNeXt backbone.
 
-    Please refer to the `paper <https://arxiv.org/abs/1611.05431>`_ for
+    Please refer to the `paper <https://arxiv.org/abs/1611.05431>`__ for
     details.
 
     Args:

--- a/mmcls/models/backbones/seresnet.py
+++ b/mmcls/models/backbones/seresnet.py
@@ -57,7 +57,7 @@ class SEBottleneck(Bottleneck):
 class SEResNet(ResNet):
     """SEResNet backbone.
 
-    Please refer to the `paper <https://arxiv.org/abs/1709.01507>`_ for
+    Please refer to the `paper <https://arxiv.org/abs/1709.01507>`__ for
     details.
 
     Args:

--- a/mmcls/models/backbones/seresnext.py
+++ b/mmcls/models/backbones/seresnext.py
@@ -95,7 +95,7 @@ class SEBottleneck(_SEBottleneck):
 class SEResNeXt(SEResNet):
     """SEResNeXt backbone.
 
-    Please refer to the `paper <https://arxiv.org/abs/1709.01507>`_ for
+    Please refer to the `paper <https://arxiv.org/abs/1709.01507>`__ for
     details.
 
     Args:

--- a/mmcls/models/backbones/swin_transformer.py
+++ b/mmcls/models/backbones/swin_transformer.py
@@ -175,8 +175,8 @@ class SwinBlockSequence(BaseModule):
 class SwinTransformer(BaseBackbone):
     """ Swin Transformer
     A PyTorch implement of : `Swin Transformer:
-    Hierarchical Vision Transformer using Shifted Windows`  -
-        https://arxiv.org/abs/2103.14030
+    Hierarchical Vision Transformer using Shifted Windows
+    <https://arxiv.org/abs/2103.14030>`_
 
     Inspiration from
     https://github.com/microsoft/Swin-Transformer

--- a/mmcls/models/backbones/vision_transformer.py
+++ b/mmcls/models/backbones/vision_transformer.py
@@ -377,8 +377,8 @@ class VisionTransformer(BaseBackbone):
     """Vision Transformer.
 
     A PyTorch impl of : `An Image is Worth 16x16 Words:
-    Transformers for Image Recognition at Scale`
-    <https://arxiv.org/abs/2010.11929>_ .
+    Transformers for Image Recognition at Scale
+    <https://arxiv.org/abs/2010.11929>`_
 
     Args:
         num_layers (int): Depth of transformer

--- a/mmcls/models/backbones/vision_transformer.py
+++ b/mmcls/models/backbones/vision_transformer.py
@@ -374,10 +374,12 @@ class HybridEmbed(nn.Module):
 
 @BACKBONES.register_module()
 class VisionTransformer(BaseBackbone):
-    """ Vision Transformer
+    """Vision Transformer.
+
     A PyTorch impl of : `An Image is Worth 16x16 Words:
-    Transformers for Image Recognition at Scale`  -
-        https://arxiv.org/abs/2010.11929
+    Transformers for Image Recognition at Scale`
+    <https://arxiv.org/abs/2010.11929>_ .
+
     Args:
         num_layers (int): Depth of transformer
         embed_dim (int): Embedding dimension

--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -178,8 +178,8 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
         """Draw `result` over `img`.
 
         Args:
-            img (str or Tensor): The image to be displayed.
-            result (Tensor): The classification results to draw over `img`.
+            img (str or ndarray): The image to be displayed.
+            result (dict): The classification results to draw over `img`.
             text_color (str or tuple or :obj:`Color`): Color of texts.
             font_scale (float): Font scales of texts.
             row_width (int): width between each row of results on the image.
@@ -192,7 +192,7 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
                 Default: None.
 
         Returns:
-            img (Tensor): Only if not `show` or `out_file`
+            img (ndarray): Only if not `show` or `out_file`
         """
         img = mmcv.imread(img)
         img = img.copy()

--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -133,15 +133,14 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
                 and reserved.
 
         Returns:
-            dict: It should contain at least 3 keys: ``loss``, ``log_vars``,
-                ``num_samples``.
-                ``loss`` is a tensor for back propagation, which can be a
-                weighted sum of multiple losses.
-                ``log_vars`` contains all the variables to be sent to the
-                logger.
-                ``num_samples`` indicates the batch size (when the model is
-                DDP, it means the batch size on each GPU), which is used for
-                averaging the logs.
+            dict: Dict of outputs. The following fields are contained.
+                - loss (torch.Tensor): A tensor for back propagation, which \
+                    can be a weighted sum of multiple losses.
+                - log_vars (dict): Dict contains all the variables to be sent \
+                    to the logger.
+                - num_samples (int): Indicates the batch size (when the model \
+                    is DDP, it means the batch size on each GPU), which is \
+                    used for averaging the logs.
         """
         losses = self(**data)
         loss, log_vars = self._parse_losses(losses)

--- a/mmcls/models/losses/accuracy.py
+++ b/mmcls/models/losses/accuracy.py
@@ -82,13 +82,11 @@ def accuracy(pred, target, topk=1, thrs=None):
             negative. Default to None.
 
     Returns:
-        float | list[float] | list[list[float]]: If the input ``topk`` is a
-            single integer, the function will return a single float or a list
-            depending on whether ``thrs`` is a single float. If the input
-            ``topk`` is a tuple, the function will return a list of results
-            of accuracies of each ``topk`` number. That is to say, as long as
-            ``topk`` is a tuple, the returned list shall be of the same length
-            as topk.
+        float | list[float] | list[list[float]]: Accuracy
+            - float: If both ``topk`` and ``thrs`` is a single value.
+            - list[float]: If one of ``topk`` or ``thrs`` is a tuple.
+            - list[list[float]]: If both ``topk`` and ``thrs`` is a tuple. \
+                And the first dim is ``topk``, the second dim is ``thrs``.
     """
     assert isinstance(topk, (int, tuple))
     if isinstance(topk, int):

--- a/mmcls/models/losses/asymmetric_loss.py
+++ b/mmcls/models/losses/asymmetric_loss.py
@@ -13,15 +13,15 @@ def asymmetric_loss(pred,
                     clip=0.05,
                     reduction='mean',
                     avg_factor=None):
-    """asymmetric loss.
+    r"""asymmetric loss.
 
-    Please refer to the `paper <https://arxiv.org/abs/2009.14119>`_ for
+    Please refer to the `paper <https://arxiv.org/abs/2009.14119>`__ for
     details.
 
     Args:
-        pred (torch.Tensor): The prediction with shape (N, *).
+        pred (torch.Tensor): The prediction with shape (N, \*).
         target (torch.Tensor): The ground truth label of the prediction with
-            shape (N, *).
+            shape (N, \*).
         weight (torch.Tensor, optional): Sample-wise loss weight with shape
             (N, ). Dafaults to None.
         gamma_pos (float): positive focusing parameter. Defaults to 0.0.
@@ -30,7 +30,7 @@ def asymmetric_loss(pred,
         clip (float, optional): Probability margin. Defaults to 0.05.
         reduction (str): The method used to reduce the loss.
             Options are "none", "mean" and "sum". If reduction is 'none' , loss
-             is same shape as pred and label. Defaults to 'mean'.
+            is same shape as pred and label. Defaults to 'mean'.
         avg_factor (int, optional): Average factor that is used to average
             the loss. Defaults to None.
 

--- a/mmcls/models/losses/cross_entropy_loss.py
+++ b/mmcls/models/losses/cross_entropy_loss.py
@@ -70,16 +70,16 @@ def binary_cross_entropy(pred,
                          weight=None,
                          reduction='mean',
                          avg_factor=None):
-    """Calculate the binary CrossEntropy loss with logits.
+    r"""Calculate the binary CrossEntropy loss with logits.
 
     Args:
-        pred (torch.Tensor): The prediction with shape (N, *).
-        label (torch.Tensor): The gt label with shape (N, *).
+        pred (torch.Tensor): The prediction with shape (N, \*).
+        label (torch.Tensor): The gt label with shape (N, \*).
         weight (torch.Tensor, optional): Element-wise weight of loss with shape
-             (N, ). Defaults to None.
+            (N, ). Defaults to None.
         reduction (str): The method used to reduce the loss.
             Options are "none", "mean" and "sum". If reduction is 'none' , loss
-             is same shape as pred and label. Defaults to 'mean'.
+            is same shape as pred and label. Defaults to 'mean'.
         avg_factor (int, optional): Average factor that is used to average
             the loss. Defaults to None.
 

--- a/mmcls/models/losses/focal_loss.py
+++ b/mmcls/models/losses/focal_loss.py
@@ -12,12 +12,12 @@ def sigmoid_focal_loss(pred,
                        alpha=0.25,
                        reduction='mean',
                        avg_factor=None):
-    """Sigmoid focal loss.
+    r"""Sigmoid focal loss.
 
     Args:
-        pred (torch.Tensor): The prediction with shape (N, *).
+        pred (torch.Tensor): The prediction with shape (N, \*).
         target (torch.Tensor): The ground truth label of the prediction with
-            shape (N, *).
+            shape (N, \*).
         weight (torch.Tensor, optional): Sample-wise loss weight with shape
             (N, ). Dafaults to None.
         gamma (float): The gamma for calculating the modulating factor.
@@ -82,16 +82,16 @@ class FocalLoss(nn.Module):
                 weight=None,
                 avg_factor=None,
                 reduction_override=None):
-        """Sigmoid focal loss.
+        r"""Sigmoid focal loss.
 
         Args:
-            pred (torch.Tensor): The prediction with shape (N, *).
+            pred (torch.Tensor): The prediction with shape (N, \*).
             target (torch.Tensor): The ground truth label of the prediction
-                with shape (N, *).
+                with shape (N, \*).
             weight (torch.Tensor, optional): Sample-wise loss weight with shape
-            (N, *). Dafaults to None.
+                (N, \*). Dafaults to None.
             avg_factor (int, optional): Average factor that is used to average
-            the loss. Defaults to None.
+                the loss. Defaults to None.
             reduction_override (str, optional): The method used to reduce the
                 loss into a scalar. Options are "none", "mean" and "sum".
                 Defaults to None.

--- a/mmcls/models/losses/label_smooth_loss.py
+++ b/mmcls/models/losses/label_smooth_loss.py
@@ -11,8 +11,9 @@ from .utils import convert_to_one_hot
 @LOSSES.register_module()
 class LabelSmoothLoss(nn.Module):
     r"""Intializer for the label smoothed cross entropy loss.
-    Refers to `Rethinking the Inception Architecture for Computer Vision` -
-        https://arxiv.org/abs/1512.00567
+
+    Refers to `Rethinking the Inception Architecture for Computer Vision
+    <https://arxiv.org/abs/1512.00567>`_
 
     This decreases gap between output scores and encourages generalization.
     Labels provided to forward can be one-hot like vectors (NxC) or class
@@ -34,7 +35,7 @@ class LabelSmoothLoss(nn.Module):
         as the original paper as:
 
         .. math::
-        (1-\epsilon)\delta_{k, y} + \frac{\epsilon}{K}
+            (1-\epsilon)\delta_{k, y} + \frac{\epsilon}{K}
 
         where epsilon is the `label_smooth_val`, K is the num_classes and
         delta(k,y) is Dirac delta, which equals 1 for k=y and 0 otherwise.
@@ -43,13 +44,13 @@ class LabelSmoothLoss(nn.Module):
         method as the facebookresearch/ClassyVision repo as:
 
         .. math::
-        \frac{\delta_{k, y} + \epsilon/K}{1+\epsilon}
+            \frac{\delta_{k, y} + \epsilon/K}{1+\epsilon}
 
         if the mode is "multi_label", this will accept labels from multi-label
         task and smoothing them as:
 
         .. math::
-        (1-2\epsilon)\delta_{k, y} + \epsilon
+            (1-2\epsilon)\delta_{k, y} + \epsilon
     """
 
     def __init__(self,
@@ -124,6 +125,23 @@ class LabelSmoothLoss(nn.Module):
                 avg_factor=None,
                 reduction_override=None,
                 **kwargs):
+        r"""Label smooth loss.
+
+        Args:
+            pred (torch.Tensor): The prediction with shape (N, \*).
+            label (torch.Tensor): The ground truth label of the prediction
+                with shape (N, \*).
+            weight (torch.Tensor, optional): Sample-wise loss weight with shape
+                (N, \*). Dafaults to None.
+            avg_factor (int, optional): Average factor that is used to average
+                the loss. Defaults to None.
+            reduction_override (str, optional): The method used to reduce the
+                loss into a scalar. Options are "none", "mean" and "sum".
+                Defaults to None.
+
+        Returns:
+            torch.Tensor: Loss.
+        """
         if self.num_classes is not None:
             assert self.num_classes == cls_score.shape[1], \
                 f'num_classes should equal to cls_score.shape[1], ' \

--- a/mmcls/models/losses/utils.py
+++ b/mmcls/models/losses/utils.py
@@ -57,11 +57,11 @@ def weighted_loss(loss_func):
     """Create a weighted version of a given loss function.
 
     To use this decorator, the loss function must have the signature like
-    `loss_func(pred, target, **kwargs)`. The function only needs to compute
+    ``loss_func(pred, target, **kwargs)``. The function only needs to compute
     element-wise loss without any reduction. This decorator will add weight
     and reduction arguments to the function. The decorated function will have
-    the signature like `loss_func(pred, target, weight=None, reduction='mean',
-    avg_factor=None, **kwargs)`.
+    the signature like ``loss_func(pred, target, weight=None, reduction='mean',
+    avg_factor=None, **kwargs)``.
 
     :Example:
 

--- a/mmcls/models/utils/augment/augments.py
+++ b/mmcls/models/utils/augment/augments.py
@@ -9,6 +9,7 @@ class Augments(object):
     """Data augments.
 
     We implement some data augmentation methods, such as mixup, cutmix.
+
     Args:
         augments_cfg (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict`):
             Config dict of augments

--- a/mmcls/models/utils/embed.py
+++ b/mmcls/models/utils/embed.py
@@ -10,6 +10,7 @@ class PatchEmbed(BaseModule):
     """Image to Patch Embedding.
 
     We use a conv layer to implement PatchEmbed.
+
     Args:
         img_size (int | tuple): The size of input image. Default: 224
         in_channels (int): The num of input channels. Default: 3
@@ -84,6 +85,7 @@ class HybridEmbed(BaseModule):
 
     Extract feature map from CNN, flatten,
     project to embedding dim.
+
     Args:
         backbone (nn.Module): CNN backbone
         img_size (int | tuple): The size of input image. Default: 224


### PR DESCRIPTION
1. Add API Reference in the docs 
2. Fix docs config, add some modules in `auto_mock_imports`, and eliminate most Warnings
3. Replace some relative links in docs to Github link, and then it will work well in readthedocs pages.
4. Format docstring for reStructuredText syntax.