### PR TITLE
[Fix] Fix a tracing bug in PyTorch 1.6

### DIFF
--- a/mmcls/models/heads/cls_head.py
+++ b/mmcls/models/heads/cls_head.py
@@ -3,6 +3,7 @@ import torch.nn.functional as F
 
 from mmcls.models.losses import Accuracy
 from ..builder import HEADS, build_loss
+from ..utils import is_tracing
 from .base_head import BaseHead
 
 
@@ -63,7 +64,7 @@ class ClsHead(BaseHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
 
-        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        on_trace = is_tracing()
         if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())

--- a/mmcls/models/heads/linear_head.py
+++ b/mmcls/models/heads/linear_head.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ..builder import HEADS
+from ..utils import is_tracing
 from .cls_head import ClsHead
 
 
@@ -42,7 +43,7 @@ class LinearClsHead(ClsHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
 
-        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        on_trace = is_tracing()
         if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())

--- a/mmcls/models/heads/multi_label_head.py
+++ b/mmcls/models/heads/multi_label_head.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as F
 
 from ..builder import HEADS, build_loss
+from ..utils import is_tracing
 from .base_head import BaseHead
 
 
@@ -48,7 +49,7 @@ class MultiLabelClsHead(BaseHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.sigmoid(cls_score) if cls_score is not None else None
 
-        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        on_trace = is_tracing()
         if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())

--- a/mmcls/models/heads/multi_label_linear_head.py
+++ b/mmcls/models/heads/multi_label_linear_head.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ..builder import HEADS
+from ..utils import is_tracing
 from .multi_label_head import MultiLabelClsHead
 
 
@@ -52,7 +53,7 @@ class MultiLabelLinearClsHead(MultiLabelClsHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.sigmoid(cls_score) if cls_score is not None else None
 
-        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        on_trace = is_tracing()
         if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())

--- a/mmcls/models/heads/vision_transformer_head.py
+++ b/mmcls/models/heads/vision_transformer_head.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 from mmcv.cnn import build_activation_layer, constant_init, kaiming_init
 
 from ..builder import HEADS
+from ..utils import is_tracing
 from .cls_head import ClsHead
 
 
@@ -69,7 +70,7 @@ class VisionTransformerClsHead(ClsHead):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
 
-        on_trace = hasattr(torch.jit, 'is_tracing') and torch.jit.is_tracing()
+        on_trace = is_tracing()
         if torch.onnx.is_in_onnx_export() or on_trace:
             return pred
         pred = list(pred.detach().cpu().numpy())

--- a/mmcls/models/utils/__init__.py
+++ b/mmcls/models/utils/__init__.py
@@ -2,7 +2,7 @@ from .attention import ShiftWindowMSA
 from .augment.augments import Augments
 from .channel_shuffle import channel_shuffle
 from .embed import HybridEmbed, PatchEmbed, PatchMerging
-from .helpers import to_2tuple, to_3tuple, to_4tuple, to_ntuple
+from .helpers import is_tracing, to_2tuple, to_3tuple, to_4tuple, to_ntuple
 from .inverted_residual import InvertedResidual
 from .make_divisible import make_divisible
 from .se_layer import SELayer
@@ -10,5 +10,5 @@ from .se_layer import SELayer
 __all__ = [
     'channel_shuffle', 'make_divisible', 'InvertedResidual', 'SELayer',
     'to_ntuple', 'to_2tuple', 'to_3tuple', 'to_4tuple', 'PatchEmbed',
-    'PatchMerging', 'HybridEmbed', 'Augments', 'ShiftWindowMSA'
+    'PatchMerging', 'HybridEmbed', 'Augments', 'ShiftWindowMSA', 'is_tracing'
 ]

--- a/mmcls/models/utils/helpers.py
+++ b/mmcls/models/utils/helpers.py
@@ -1,6 +1,20 @@
 import collections.abc
 from itertools import repeat
 
+import torch
+
+
+def is_tracing() -> bool:
+    if hasattr(torch.jit, 'is_tracing'):
+        on_trace = torch.jit.is_tracing()
+        # In PyTorch 1.6, torch.jit.is_tracing has a bug.
+        # Refers to https://github.com/pytorch/pytorch/issues/42448
+        if isinstance(on_trace, bool):
+            return on_trace
+        else:
+            return torch._C._is_tracing()
+    return False
+
 
 # From PyTorch internals
 def _ntuple(n):


### PR DESCRIPTION
In PyTorch 1.6, `torch.jit.is_tracing` returns an object by mistake. Refers to https://github.com/pytorch/pytorch/issues/42448#issue-671987165
Here I add a helper function `is_tracing` to avoid it. And use this function in all heads.