### PR TITLE
[Fix] Fix broken _base_ link in a resnet config.

### DIFF
--- a/configs/resnet/resnet50_b64x32_warmup_label_smooth_imagenet.py
+++ b/configs/resnet/resnet50_b64x32_warmup_label_smooth_imagenet.py
@@ -1,4 +1,4 @@
-_base_ = ['./resnet50_batch2048_warmup.py']
+_base_ = ['./resnet50_b64x32_warmup_imagenet.py']
 model = dict(
     head=dict(
         type='LinearClsHead',


### PR DESCRIPTION
The base link in `resnet50_b64x32_warmup_label_smooth_imagenet.py` is broken, now fix it.