### PR TITLE
[Fix] Fix shufflenet_v1.py default value conflict.

### DIFF
--- a/mmcls/models/backbones/shufflenet_v1.py
+++ b/mmcls/models/backbones/shufflenet_v1.py
@@ -23,7 +23,7 @@ class ShuffleUnit(BaseModule):
         groups (int): The number of groups to be used in grouped 1x1
             convolutions in each ShuffleUnit. Default: 3
         first_block (bool): Whether it is the first ShuffleUnit of a
-            sequential ShuffleUnits. Default: False, which means not using the
+            sequential ShuffleUnits. Default: True, which means not using the
             grouped 1x1 convolution.
         combine (str): The ways to combine the input and output
             branches. Default: 'add'.
@@ -45,7 +45,7 @@ class ShuffleUnit(BaseModule):
                  in_channels,
                  out_channels,
                  groups=3,
-                 first_block=False,
+                 first_block=True,
                  combine='add',
                  conv_cfg=None,
                  norm_cfg=dict(type='BN'),

--- a/mmcls/models/backbones/shufflenet_v1.py
+++ b/mmcls/models/backbones/shufflenet_v1.py
@@ -45,7 +45,7 @@ class ShuffleUnit(BaseModule):
                  in_channels,
                  out_channels,
                  groups=3,
-                 first_block=True,
+                 first_block=False,
                  combine='add',
                  conv_cfg=None,
                  norm_cfg=dict(type='BN'),


### PR DESCRIPTION
 Fix the conflict between the document and the code default item.The default value of "first_block" in doc is False, when the acctual default value of "first_block" is True in codebase.