### PR TITLE
[Docs] Fix `Open in colab` link in Colab tutorials.

### DIFF
--- a/docs_zh-CN/tutorials/MMClassification_python_cn.ipynb
+++ b/docs_zh-CN/tutorials/MMClassification_python_cn.ipynb
@@ -6,7 +6,7 @@
     "id": "XjQxmm04iTx4"
    },
    "source": [
-    "<a href=\"https://github.com/open-mmlab/mmclassification/blob/master/docs_zh-CN/tutorials/MMClassification_python_cn.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/open-mmlab/mmclassification/blob/master/docs_zh-CN/tutorials/MMClassification_python_cn.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/docs_zh-CN/tutorials/MMClassification_tools_cn.ipynb
+++ b/docs_zh-CN/tutorials/MMClassification_tools_cn.ipynb
@@ -7,7 +7,7 @@
     "tags": []
    },
    "source": [
-    "<a href=\"https://github.com/open-mmlab/mmclassification/blob/master/docs_zh-CN/tutorials/MMClassification_tools_cn.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/open-mmlab/mmclassification/blob/master/docs_zh-CN/tutorials/MMClassification_tools_cn.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {


### PR DESCRIPTION
The `Open in colab` is wrong, now fix it.
You can read it in Colab now:
[MMClassification_python_cn](https://colab.research.google.com/github/open-mmlab/mmclassification/blob/master/docs_zh-CN/tutorials/MMClassification_python_cn.ipynb)
[MMClassification_tools_cn](https://colab.research.google.com/github/open-mmlab/mmclassification/blob/master/docs_zh-CN/tutorials/MMClassification_tools_cn.ipynb)