### PR TITLE
Output pdf and epub formats for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,9 @@
 version: 2
 
+formats: all
+
 python:
-    version: 3.7
-    install:
-      - requirements: requirements/docs.txt
-      - requirements: requirements/readthedocs.txt
+  version: 3.7
+  install:
+    - requirements: requirements/docs.txt
+    - requirements: requirements/readthedocs.txt


### PR DESCRIPTION
## Motivation
Add more formats (pdf, epub) of documentation. Refers to https://github.com/open-mmlab/mmdetection/pull/5738

## Modification
The format field in readthedocs.yml is modified.