### PR TITLE
[Enhance] Avoid unnecessary `listdir` when building `ImageNet`

### DIFF
--- a/mmcls/datasets/imagenet.py
+++ b/mmcls/datasets/imagenet.py
@@ -49,11 +49,8 @@ def get_samples(root, folder_to_idx, extensions):
     """
     samples = []
     root = os.path.expanduser(root)
-    for folder_name in sorted(os.listdir(root)):
+    for folder_name in sorted(list(folder_to_idx.keys())):
         _dir = os.path.join(root, folder_name)
-        if not os.path.isdir(_dir):
-            continue
-
         for _, _, fns in sorted(os.walk(_dir)):
             for fn in sorted(fns):
                 if has_file_allowed_extension(fn, extensions):


### PR DESCRIPTION
## Motivation
Implementation of the `ImageNet` dataset contains duplicated operations: one extra call of `os.listdir` and calls of `os.path.isdir` for every class folder in the dataset. Since this loader can be used for much more larger datasets than ImageNet, it should be as effective as possible. In pytorch's ImageFolder dataset which is basically pretty close to the considered `ImageNet` class, these duplications are eliminated. 

## Modification

Duplicated calls were eliminated (all the top level folder structure checks are concentrated in `find_folders`).

## BC-breaking (Optional)

This PR doesn't brake anything.
