### PR TITLE
[Fix] Avoid installing both opencv and opencv-headless.

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,1 +1,1 @@
-albumentations>=0.3.2
+albumentations>=0.3.2 --no-binary imgaug,albumentations


### PR DESCRIPTION
## Motivation

Our optional dependency `albumentations` may install both `opencv` and `opencv-headless`. Refers to [the docs](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies).

## Modification

This PR updates the installation of `albumentations` to prevent using a wheel distribution of it with `opencv-headless `dependency. Refers to https://github.com/open-mmlab/mmpose/pull/833

## BC-breaking (Optional)

No

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
