### PR TITLE
[WIP] Add online label smooth (OLS) loss support

### DIFF
--- a/configs/_base_/models/resnet50_ols.py
+++ b/configs/_base_/models/resnet50_ols.py
@@ -1,0 +1,22 @@
+# model settings
+model = dict(
+    type='ImageClassifier',
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(3, ),
+        style='pytorch'),
+    neck=dict(type='GlobalAveragePooling'),
+    head=dict(
+        type='LinearClsHead',
+        num_classes=1000,
+        in_channels=2048,
+        loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
+        topk=(1, 5),
+    ))
+custom_hooks = dict(
+    type='OLSHook',
+    priority='NORMAL',
+    lambda_ols=0.5
+)

--- a/configs/resnet/resnet50_b32x8_ols_imagenet.py
+++ b/configs/resnet/resnet50_b32x8_ols_imagenet.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/resnet50_ols.py',
+    '../_base_/datasets/imagenet_bs32.py',
+    '../_base_/schedules/imagenet_bs256.py',
+    '../_base_/default_runtime.py'
+]

--- a/mmcls/models/losses/__init__.py
+++ b/mmcls/models/losses/__init__.py
@@ -4,6 +4,7 @@ from .cross_entropy_loss import (CrossEntropyLoss, binary_cross_entropy,
                                  cross_entropy)
 from .focal_loss import FocalLoss, sigmoid_focal_loss
 from .label_smooth_loss import LabelSmoothLoss
+from .online_label_smooth_loss import OnlineLabelSmoothLoss, OLSHook
 from .utils import (convert_to_one_hot, reduce_loss, weight_reduce_loss,
                     weighted_loss)
 
@@ -11,5 +12,5 @@ __all__ = [
     'accuracy', 'Accuracy', 'asymmetric_loss', 'AsymmetricLoss',
     'cross_entropy', 'binary_cross_entropy', 'CrossEntropyLoss', 'reduce_loss',
     'weight_reduce_loss', 'LabelSmoothLoss', 'weighted_loss', 'FocalLoss',
-    'sigmoid_focal_loss', 'convert_to_one_hot'
+    'sigmoid_focal_loss', 'convert_to_one_hot', 'OnlineLabelSmoothLoss', 'OLSHook'
 ]

--- a/mmcls/models/losses/online_label_smooth_loss.py
+++ b/mmcls/models/losses/online_label_smooth_loss.py
@@ -1,0 +1,64 @@
+r"""
+This is an implementation of online label smooth (OLS) loss from: `Delving Deep into Label Smoothing`
+"""
+
+import torch
+import torch.nn.functional as F
+
+from mmcv.runner import Hook
+
+
+class OLSHook(Hook):
+    r"""
+    OLS is implemented in the form of custom hook. To activate OLS, please add the following cfg:
+    ``` python
+    custom_hooks = dict(
+        type='OLSHook',
+        priority='NORMAL',
+        lambda_ols=0.5,
+    )
+    ```
+    """
+    def __init__(self, lambda_ols=0.5):
+        self.lambda_ols = lambda_ols
+
+    def update_soft_label(self, output, target):
+        with torch.no_grad():
+            logits = torch.softmax(output, dim=1)
+            sort_args = torch.argsort(logits, dim=1, descending=True)
+            for k in range(output.shape[0]):
+                if target[k] != sort_args[k, 0]:
+                    continue
+                self.soft_labels_curr[target[k]] += logits[k]
+                self.correct_labels_cnt[target[k]] += 1
+
+    def soft_cross_entropy(self, output, target):
+        target_prob = torch.zeros_like(output)
+        batch = output.shape[0]
+        for k in range(batch):
+            target_prob[k] = self.soft_labels[target[k]]
+        log_like = -F.log_softmax(output, dim=1)
+        loss = torch.sum(torch.mul(log_like, target_prob)) / batch
+        return loss
+
+    def compute_ols_loss(self, output, target):
+        ols_loss = self.compute_ols_loss(output, target)
+        ori_loss = self.compute_loss(output, target)
+        return self.lambda_ols * ols_loss + (1 - self.lambda_ols) * ori_loss
+
+    def before_run(self, runner):
+        self.num_classes = runner.model.head.num_classes
+        self.compute_loss = runner.model.head.compute_loss
+        self.soft_labels = torch.zeros(self.num_classes, self.num_classes, dtype=torch.float32).cuda()
+        self.soft_labels[:, :] = 1. / self.num_classes
+        self.soft_labels.requires_grad = False
+
+    def before_train_epoch(self, runner):
+        self.soft_labels_curr = torch.zeros(self.num_classes, self.num_classes, dtype=torch.float32).cuda()
+        self.correct_labels_cnt = torch.zeros(self.num_classes, dtype=torch.float32).cuda()
+
+    def before_train_iter(self, runner):
+        pass
+
+    def after_train_iter(self, runner):
+        pass

--- a/mmcls/models/losses/online_label_smooth_loss.py
+++ b/mmcls/models/losses/online_label_smooth_loss.py
@@ -3,12 +3,78 @@ This is an implementation of online label smooth (OLS) loss from: `Delving Deep 
 """
 
 import torch
+from torch import nn
 import torch.nn.functional as F
 from torch.nn.parallel.distributed import DistributedDataParallel
 
-from mmcv.runner import Hook
+from mmcv.runner import Hook, HOOKS
+from ..builder import LOSSES
 
 
+@LOSSES.register_module()
+class OnlineLabelSmoothLoss(nn.Module):
+    r"""
+    The online label smooth loss following standard PyTorch loss format.
+
+    Args:
+        origin_loss (nn.Moudle): the original loss function.
+        num_classes (int): the number of classes for classfication task.
+        lambda_ols (float): the weight factor for soft label loss.
+    """
+    def __init__(self, origin_loss, num_classes, lambda_ols=0.5):
+        super(OnlineLabelSmoothLoss, self).__init__()
+
+        assert isinstance(origin_loss, nn.Module), origin_loss
+        self.origin_loss = origin_loss
+        self.num_classes = num_classes
+        self.lambda_ols = lambda_ols
+
+        self.soft_labels = torch.zeros(num_classes, num_classes, dtype=torch.float32).cuda()
+        self.soft_labels[:, :] = 1. / num_classes
+        self.soft_labels.requires_grad = False
+        self.reset_label_accumulator()
+
+    def reset_label_accumulator(self):
+        self.soft_labels_update = torch.zeros(self.num_classes, self.num_classes, dtype=torch.float32).cuda()
+        self.correct_labels_cnt = torch.zeros(self.num_classes, dtype=torch.float32).cuda()
+        self.soft_labels_update.requires_grad = False
+        self.correct_labels_cnt.requires_grad = False
+
+    def soft_label_regularization(self):
+        for class_idx in range(self.num_classes):
+            if self.correct_labels_cnt[class_idx].max() < 0.5:
+                self.soft_labels[class_idx] = 1. / self.num_classes
+            else:
+                self.soft_labels[class_idx] = self.soft_labels_update[class_idx] / self.correct_labels_cnt[class_idx]
+        self.reset_label_accumulator()
+
+    def update_soft_label(self, input, target):
+        with torch.no_grad():
+            logits = torch.softmax(input, dim=1)
+            sort_args = torch.argsort(logits, dim=1, descending=True)
+            for k in range(input.shape[0]):
+                if target[k] != sort_args[k, 0]:
+                    continue
+                self.soft_labels_update[target[k]] += logits[k]
+                self.correct_labels_cnt[target[k]] += 1
+
+    def soft_cross_entropy(self, input, target):
+        target_prob = torch.zeros_like(input)
+        batch = input.shape[0]
+        for k in range(batch):
+            target_prob[k] = self.soft_labels[target[k]]
+        log_like = -F.log_softmax(input, dim=1)
+        loss = torch.sum(torch.mul(log_like, target_prob)) / batch
+        return loss
+
+    def forward(self, input, target, **kwargs):
+        self.update_soft_label(input, target)
+        sce_loss = self.soft_cross_entropy(input, target)
+        ori_loss = self.origin_loss(input, target, **kwargs)
+        return self.lambda_ols * sce_loss + (1 - self.lambda_ols) * ori_loss
+
+
+@HOOKS.register_module()
 class OLSHook(Hook):
     r"""
     OLS is implemented in the form of custom hook. To activate OLS, please add the following cfg:
@@ -22,31 +88,7 @@ class OLSHook(Hook):
     """
     def __init__(self, lambda_ols=0.5):
         self.lambda_ols = lambda_ols
-
-    def update_soft_label(self, output, target):
-        with torch.no_grad():
-            logits = torch.softmax(output, dim=1)
-            sort_args = torch.argsort(logits, dim=1, descending=True)
-            for k in range(output.shape[0]):
-                if target[k] != sort_args[k, 0]:
-                    continue
-                self.soft_labels_curr[target[k]] += logits[k]
-                self.correct_labels_cnt[target[k]] += 1
-
-    def soft_cross_entropy(self, output, target):
-        target_prob = torch.zeros_like(output)
-        batch = output.shape[0]
-        for k in range(batch):
-            target_prob[k] = self.soft_labels[target[k]]
-        log_like = -F.log_softmax(output, dim=1)
-        loss = torch.sum(torch.mul(log_like, target_prob)) / batch
-        return loss
-
-    def compute_ols_loss(self, output, target):
-        self.update_soft_label(output, target)
-        sce_loss = self.soft_cross_entropy(output, target)
-        ori_loss = self.compute_loss(output, target)
-        return self.lambda_ols * sce_loss + (1 - self.lambda_ols) * ori_loss
+        self.ols_loss = None
 
     def before_run(self, runner):
         # Record model and extract num_classes and loss from it
@@ -54,26 +96,16 @@ class OLSHook(Hook):
             self.model = runner.model.module
         else:
             self.model = runner.model
-        self.num_classes = self.model.head.num_classes
-        self.compute_loss = self.model.head.compute_loss
 
-        # Initialize the soft label
-        assert isinstance(self.num_classes, int)
-        self.soft_labels = torch.zeros(self.num_classes, self.num_classes, dtype=torch.float32).cuda()
-        self.soft_labels[:, :] = 1. / self.num_classes
-        self.soft_labels.requires_grad = False
+        # Establish the OnlineLabelSmooth loss
+        self.ols_loss = OnlineLabelSmoothLoss(
+            origin_loss=self.model.head.compute_loss,
+            num_classes=self.model.head.num_classes,
+            lambda_ols=self.lambda_ols)
 
     def before_train_epoch(self, runner):
-        self.soft_labels_curr = torch.zeros(self.num_classes, self.num_classes, dtype=torch.float32).cuda()
-        self.soft_labels_curr.requires_grad = False
-        self.correct_labels_cnt = torch.zeros(self.num_classes, dtype=torch.float32).cuda()
-        self.model.head.compute_loss = self.compute_ols_loss
+        self.model.head.compute_loss = self.ols_loss
 
     def after_train_epoch(self, runner):
-        self.model.head.compute_loss = self.compute_loss
-        # Soft label regularization
-        for class_idx in range(self.num_classes):
-            if self.correct_labels_cnt[class_idx].max() < 0.5:
-                self.soft_labels[class_idx] = 1. / self.args.num_classes
-            else:
-                self.soft_labels[class_idx] = self.soft_labels_curr[class_idx] / self.correct_labels_cnt[class_idx]
+        self.model.head.compute_loss = self.ols_loss.origin_loss
+        self.ols_loss.soft_label_regularization()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Add OLS support for better performance compared with original label smooth. In addition, the OLS loss works better under the noisy label case.

## Modification

A new loss named online label smooth (OLS) following standard PyTorch loss format is provided. A new hook to plant the OLS loss to the mmcv-style training pipeline is provided. Related configs are given

## Use cases (Optional)

The OLS loss could be activated with the following script in `mmclassification` project
``` bash
python3 -m torch.distributed.launch \
    --nproc_per_node=8 \
    --master_port=23333 \
    tools/train.py configs/resnet/resnet50_b32x8_ols_imagenet.py \
    --launcher pytorch
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
