### PR TITLE
[Enhance] Better result visualization

### DIFF
--- a/mmcls/apis/inference.py
+++ b/mmcls/apis/inference.py
@@ -96,6 +96,9 @@ def show_result_pyplot(model, img, result, fig_size=(15, 10), wait_time=0):
         img (str or np.ndarray): Image filename or loaded image.
         result (list): The classification result.
         fig_size (tuple): Figure size of the pyplot figure.
+            Defaults to (15, 10).
+        wait_time (int): How many seconds to display the image.
+            Defaults to 0.
     """
     if hasattr(model, 'module'):
         model = model.module

--- a/mmcls/apis/inference.py
+++ b/mmcls/apis/inference.py
@@ -1,6 +1,5 @@
 import warnings
 
-import matplotlib.pyplot as plt
 import mmcv
 import numpy as np
 import torch
@@ -89,7 +88,7 @@ def inference_model(model, img):
     return result
 
 
-def show_result_pyplot(model, img, result, fig_size=(15, 10)):
+def show_result_pyplot(model, img, result, fig_size=(15, 10), wait_time=0):
     """Visualize the classification results on the image.
 
     Args:
@@ -100,7 +99,5 @@ def show_result_pyplot(model, img, result, fig_size=(15, 10)):
     """
     if hasattr(model, 'module'):
         model = model.module
-    img = model.show_result(img, result, show=False)
-    plt.figure(figsize=fig_size)
-    plt.imshow(mmcv.bgr2rgb(img))
-    plt.show()
+    model.show_result(
+        img, result, show=True, fig_size=fig_size, wait_time=wait_time)

--- a/mmcls/core/visualization/__init__.py
+++ b/mmcls/core/visualization/__init__.py
@@ -1,0 +1,3 @@
+from .image import color_val_matplotlib, imshow_cls_result
+
+__all__ = ['imshow_cls_result', 'color_val_matplotlib']

--- a/mmcls/core/visualization/__init__.py
+++ b/mmcls/core/visualization/__init__.py
@@ -1,3 +1,3 @@
-from .image import color_val_matplotlib, imshow_cls_result
+from .image import color_val_matplotlib, imshow_infos
 
-__all__ = ['imshow_cls_result', 'color_val_matplotlib']
+__all__ = ['imshow_infos', 'color_val_matplotlib']

--- a/mmcls/core/visualization/image.py
+++ b/mmcls/core/visualization/image.py
@@ -50,6 +50,8 @@ def imshow_infos(img,
     Returns:
         np.ndarray: The image with extra infomations.
     """
+    img = mmcv.imread(img).astype(np.uint8)
+
     x, y = 3, row_width // 2
     text_color = color_val_matplotlib(text_color)
 

--- a/mmcls/core/visualization/image.py
+++ b/mmcls/core/visualization/image.py
@@ -37,7 +37,8 @@ def imshow_cls_result(img,
     width, height = img.shape[1], img.shape[0]
     img = np.ascontiguousarray(img)
 
-    fig = plt.figure(win_name, frameon=False, figsize=fig_size)
+    # A proper dpi for image save with default font size.
+    fig = plt.figure(win_name, frameon=False, figsize=fig_size, dpi=36)
     plt.title(win_name)
     canvas = fig.canvas
     dpi = fig.get_dpi()
@@ -81,6 +82,15 @@ def imshow_cls_result(img,
     img = mmcv.rgb2bgr(img)
 
     if show:
+        # Matplotlib will adjust text size depends on window size and image
+        # aspect ratio. It's hard to get, so here we set an adaptive dpi
+        # according to screen height. 20 here is an empirical parameter.
+        fig_manager = plt.get_current_fig_manager()
+        if hasattr(fig_manager, 'window'):
+            # Figure manager doesn't have window if no screen.
+            screen_dpi = fig_manager.window.winfo_screenheight() // 20
+            fig.set_dpi(screen_dpi)
+
         # We do not use cv2 for display because in some cases, opencv will
         # conflict with Qt, it will output a warning: Current thread
         # is not the object's thread. You can refer to

--- a/mmcls/core/visualization/image.py
+++ b/mmcls/core/visualization/image.py
@@ -1,0 +1,98 @@
+import matplotlib.pyplot as plt
+import mmcv
+import numpy as np
+
+EPS = 1e-2
+
+
+def color_val_matplotlib(color):
+    """Convert various input in BGR order to normalized RGB matplotlib color
+    tuples,
+
+    Args:
+        color (:obj:`Color`/str/tuple/int/ndarray): Color inputs
+
+    Returns:
+        tuple[float]: A tuple of 3 normalized floats indicating RGB channels.
+    """
+    color = mmcv.color_val(color)
+    color = [color / 255 for color in color[::-1]]
+    return tuple(color)
+
+
+def imshow_cls_result(img,
+                      result,
+                      text_color='white',
+                      font_size=26,
+                      row_width=20,
+                      win_name='',
+                      show=True,
+                      fig_size=(15, 10),
+                      wait_time=0,
+                      out_file=None):
+    x, y = 3, row_width // 2
+    text_color = color_val_matplotlib(text_color)
+
+    img = mmcv.bgr2rgb(img)
+    width, height = img.shape[1], img.shape[0]
+    img = np.ascontiguousarray(img)
+
+    fig = plt.figure(win_name, frameon=False, figsize=fig_size)
+    plt.title(win_name)
+    canvas = fig.canvas
+    dpi = fig.get_dpi()
+    # add a small EPS to avoid precision lost due to matplotlib's truncation
+    # (https://github.com/matplotlib/matplotlib/issues/15363)
+    fig.set_size_inches((width + EPS) / dpi, (height + EPS) / dpi)
+
+    # remove white edges by set subplot margin
+    plt.subplots_adjust(left=0, right=1, bottom=0, top=1)
+    ax = plt.gca()
+    ax.axis('off')
+
+    for k, v in result.items():
+        if isinstance(v, float):
+            v = f'{v:.2f}'
+        label_text = f'{k}: {v}'
+        ax.text(
+            x,
+            y,
+            f'{label_text}',
+            bbox={
+                'facecolor': 'black',
+                'alpha': 0.7,
+                'pad': 0.2,
+                'edgecolor': 'none',
+                'boxstyle': 'round'
+            },
+            color=text_color,
+            fontsize=font_size,
+            family='monospace',
+            verticalalignment='top',
+            horizontalalignment='left')
+        y += row_width
+
+    plt.imshow(img)
+    stream, _ = canvas.print_to_buffer()
+    buffer = np.frombuffer(stream, dtype='uint8')
+    img_rgba = buffer.reshape(height, width, 4)
+    rgb, _ = np.split(img_rgba, [3], axis=2)
+    img = rgb.astype('uint8')
+    img = mmcv.rgb2bgr(img)
+
+    if show:
+        # We do not use cv2 for display because in some cases, opencv will
+        # conflict with Qt, it will output a warning: Current thread
+        # is not the object's thread. You can refer to
+        # https://github.com/opencv/opencv-python/issues/46 for details
+        if wait_time == 0:
+            plt.show()
+        else:
+            plt.show(block=False)
+            plt.pause(wait_time)
+    if out_file is not None:
+        mmcv.imwrite(img, out_file)
+
+    plt.close()
+
+    return img

--- a/mmcls/core/visualization/image.py
+++ b/mmcls/core/visualization/image.py
@@ -43,7 +43,7 @@ def imshow_infos(img,
         win_name (str): The image title. Defaults to ''
         show (bool): Whether to show the image. Defaults to True.
         fig_size (tuple): Image show figure size. Defaults to (15, 10).
-        wait_time (int): Show time of image display.
+        wait_time (int): How many seconds to display the image. Defaults to 0.
         out_file (Optional[str]): The filename to write the image.
             Defaults to None.
 

--- a/mmcls/core/visualization/image.py
+++ b/mmcls/core/visualization/image.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import mmcv
 import numpy as np
 
+# A small value
 EPS = 1e-2
 
 
@@ -10,7 +11,7 @@ def color_val_matplotlib(color):
     tuples,
 
     Args:
-        color (:obj:`Color`/str/tuple/int/ndarray): Color inputs
+        color (:obj:`mmcv.Color`/str/tuple/int/ndarray): Color inputs
 
     Returns:
         tuple[float]: A tuple of 3 normalized floats indicating RGB channels.
@@ -20,16 +21,35 @@ def color_val_matplotlib(color):
     return tuple(color)
 
 
-def imshow_cls_result(img,
-                      result,
-                      text_color='white',
-                      font_size=26,
-                      row_width=20,
-                      win_name='',
-                      show=True,
-                      fig_size=(15, 10),
-                      wait_time=0,
-                      out_file=None):
+def imshow_infos(img,
+                 infos,
+                 text_color='white',
+                 font_size=26,
+                 row_width=20,
+                 win_name='',
+                 show=True,
+                 fig_size=(15, 10),
+                 wait_time=0,
+                 out_file=None):
+    """Show image with extra infomation.
+
+    Args:
+        img (str | ndarray): The image to be displayed.
+        infos (dict): Extra infos to display in the image.
+        text_color (:obj:`mmcv.Color`/str/tuple/int/ndarray): Extra infos
+            display color. Defaults to 'white'.
+        font_size (int): Extra infos display font size. Defaults to 26.
+        row_width (int): width between each row of results on the image.
+        win_name (str): The image title. Defaults to ''
+        show (bool): Whether to show the image. Defaults to True.
+        fig_size (tuple): Image show figure size. Defaults to (15, 10).
+        wait_time (int): Show time of image display.
+        out_file (Optional[str]): The filename to write the image.
+            Defaults to None.
+
+    Returns:
+        np.ndarray: The image with extra infomations.
+    """
     x, y = 3, row_width // 2
     text_color = color_val_matplotlib(text_color)
 
@@ -51,7 +71,7 @@ def imshow_cls_result(img,
     ax = plt.gca()
     ax.axis('off')
 
-    for k, v in result.items():
+    for k, v in infos.items():
         if isinstance(v, float):
             v = f'{v:.2f}'
         label_text = f'{k}: {v}'

--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributed as dist
 from mmcv.runner import BaseModule
 
-from mmcls.core.visualization import imshow_cls_result
+from mmcls.core.visualization import imshow_infos
 
 # TODO import `auto_fp16` from mmcv and delete them from mmcls
 try:
@@ -186,6 +186,7 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
             row_width (int): width between each row of results on the image.
             show (bool): Whether to show the image.
                 Default: False.
+            fig_size (tuple): Image show figure size. Defaults to (15, 10).
             win_name (str): The window name.
             wait_time (int): Value of waitKey param.
                 Default: 0.
@@ -193,12 +194,12 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
                 Default: None.
 
         Returns:
-            img (ndarray): Only if not `show` or `out_file`
+            img (ndarray): Image with overlayed results.
         """
         img = mmcv.imread(img)
         img = img.copy()
 
-        img = imshow_cls_result(
+        img = imshow_infos(
             img,
             result,
             text_color=text_color,
@@ -210,5 +211,4 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
             wait_time=wait_time,
             out_file=out_file)
 
-        if not (show or out_file):
-            return img
+        return img

--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -188,8 +188,8 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
                 Default: False.
             fig_size (tuple): Image show figure size. Defaults to (15, 10).
             win_name (str): The window name.
-            wait_time (int): Value of waitKey param.
-                Default: 0.
+            wait_time (int): How many seconds to display the image.
+                Defaults to 0.
             out_file (str or None): The filename to write the image.
                 Default: None.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools
 known_first_party = mmcls
-known_third_party = PIL,cv2,matplotlib,mmcv,mmdet,numpy,onnxruntime,packaging,pytest,seaborn,torch,torchvision,ts
+known_third_party = PIL,matplotlib,mmcv,mmdet,numpy,onnxruntime,packaging,pytest,seaborn,torch,torchvision,ts
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/tests/test_models/test_classifiers.py
+++ b/tests/test_models/test_classifiers.py
@@ -1,7 +1,6 @@
 import os.path as osp
 import tempfile
 from copy import deepcopy
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -83,16 +82,6 @@ def test_image_classifier():
         out_file = osp.join(tmpdir, 'out.png')
         model.show_result(img, result, out_file=out_file)
         assert osp.exists(out_file)
-
-        def save_show(_, *args):
-            out_path = osp.join(tmpdir, '_'.join([str(arg) for arg in args]))
-            with open(out_path, 'w') as f:
-                f.write('test')
-
-        with patch('mmcv.imshow', save_show):
-            model.show_result(
-                img, result, show=True, win_name='img', wait_time=5)
-            assert osp.exists(osp.join(tmpdir, 'img_5'))
 
 
 def test_image_classifier_with_mixup():

--- a/tests/test_utils/test_visualization.py
+++ b/tests/test_utils/test_visualization.py
@@ -29,13 +29,13 @@ def test_color():
         vis.color_val_matplotlib((0, 0, 500))
 
 
-def test_imshow_cls_results():
-    tmp_dir = osp.join(tempfile.gettempdir(), 'cls_results_image')
+def test_imshow_infos():
+    tmp_dir = osp.join(tempfile.gettempdir(), 'infos_image')
     tmp_filename = osp.join(tmp_dir, 'image.jpg')
 
     image = np.ones((10, 10, 3), np.uint8)
     result = {'pred_label': 1, 'pred_class': 'bird', 'pred_score': 0.98}
-    out_image = vis.imshow_cls_result(
+    out_image = vis.imshow_infos(
         image, result, out_file=tmp_filename, show=False)
     assert osp.isfile(tmp_filename)
     assert image.shape == out_image.shape
@@ -45,7 +45,7 @@ def test_imshow_cls_results():
     # test grayscale images
     image = np.ones((10, 10), np.uint8)
     result = {'pred_label': 1, 'pred_class': 'bird', 'pred_score': 0.98}
-    out_image = vis.imshow_cls_result(
+    out_image = vis.imshow_infos(
         image, result, out_file=tmp_filename, show=False)
     assert osp.isfile(tmp_filename)
     assert image.shape == out_image.shape[:2]
@@ -70,11 +70,11 @@ def test_imshow_cls_results():
 
     with patch('matplotlib.pyplot.show', save_args), \
             patch('matplotlib.pyplot.pause', save_args):
-        vis.imshow_cls_result(image, result, show=True, wait_time=5)
+        vis.imshow_infos(image, result, show=True, wait_time=5)
         assert osp.exists(osp.join(tmp_dir, 'args_block-False'))
         assert osp.exists(osp.join(tmp_dir, 'args_5'))
 
-        vis.imshow_cls_result(image, result, show=True, wait_time=0)
+        vis.imshow_infos(image, result, show=True, wait_time=0)
         assert osp.exists(osp.join(tmp_dir, 'args'))
 
     # test adaptive dpi
@@ -85,6 +85,6 @@ def test_imshow_cls_results():
 
     with patch('matplotlib.pyplot.get_current_fig_manager',
                mock_fig_manager), patch('matplotlib.pyplot.show'):
-        vis.imshow_cls_result(image, result, show=True)
+        vis.imshow_infos(image, result, show=True)
 
     shutil.rmtree(tmp_dir)

--- a/tests/test_utils/test_visualization.py
+++ b/tests/test_utils/test_visualization.py
@@ -3,7 +3,7 @@ import os
 import os.path as osp
 import shutil
 import tempfile
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import mmcv
 import numpy as np
@@ -17,7 +17,7 @@ def test_color():
     assert vis.color_val_matplotlib('green') == (0., 1., 0.)
     assert vis.color_val_matplotlib((1, 2, 3)) == (3 / 255, 2 / 255, 1 / 255)
     assert vis.color_val_matplotlib(100) == (100 / 255, 100 / 255, 100 / 255)
-    assert vis.color_val_matplotlib(np.zeros(3, dtype=np.int)) == (0., 0., 0.)
+    assert vis.color_val_matplotlib(np.zeros(3, dtype=int)) == (0., 0., 0.)
     # forbid white color
     with pytest.raises(TypeError):
         vis.color_val_matplotlib([255, 255, 255])
@@ -76,5 +76,15 @@ def test_imshow_cls_results():
 
         vis.imshow_cls_result(image, result, show=True, wait_time=0)
         assert osp.exists(osp.join(tmp_dir, 'args'))
+
+    # test adaptive dpi
+    def mock_fig_manager():
+        fig_manager = Mock()
+        fig_manager.window.winfo_screenheight = Mock(return_value=1440)
+        return fig_manager
+
+    with patch('matplotlib.pyplot.get_current_fig_manager',
+               mock_fig_manager), patch('matplotlib.pyplot.show'):
+        vis.imshow_cls_result(image, result, show=True)
 
     shutil.rmtree(tmp_dir)

--- a/tests/test_utils/test_visualization.py
+++ b/tests/test_utils/test_visualization.py
@@ -1,0 +1,80 @@
+# Copyright (c) Open-MMLab. All rights reserved.
+import os
+import os.path as osp
+import shutil
+import tempfile
+from unittest.mock import patch
+
+import mmcv
+import numpy as np
+import pytest
+
+from mmcls.core import visualization as vis
+
+
+def test_color():
+    assert vis.color_val_matplotlib(mmcv.Color.blue) == (0., 0., 1.)
+    assert vis.color_val_matplotlib('green') == (0., 1., 0.)
+    assert vis.color_val_matplotlib((1, 2, 3)) == (3 / 255, 2 / 255, 1 / 255)
+    assert vis.color_val_matplotlib(100) == (100 / 255, 100 / 255, 100 / 255)
+    assert vis.color_val_matplotlib(np.zeros(3, dtype=np.int)) == (0., 0., 0.)
+    # forbid white color
+    with pytest.raises(TypeError):
+        vis.color_val_matplotlib([255, 255, 255])
+    # forbid float
+    with pytest.raises(TypeError):
+        vis.color_val_matplotlib(1.0)
+    # overflowed
+    with pytest.raises(AssertionError):
+        vis.color_val_matplotlib((0, 0, 500))
+
+
+def test_imshow_cls_results():
+    tmp_dir = osp.join(tempfile.gettempdir(), 'cls_results_image')
+    tmp_filename = osp.join(tmp_dir, 'image.jpg')
+
+    image = np.ones((10, 10, 3), np.uint8)
+    result = {'pred_label': 1, 'pred_class': 'bird', 'pred_score': 0.98}
+    out_image = vis.imshow_cls_result(
+        image, result, out_file=tmp_filename, show=False)
+    assert osp.isfile(tmp_filename)
+    assert image.shape == out_image.shape
+    assert not np.allclose(image, out_image)
+    os.remove(tmp_filename)
+
+    # test grayscale images
+    image = np.ones((10, 10), np.uint8)
+    result = {'pred_label': 1, 'pred_class': 'bird', 'pred_score': 0.98}
+    out_image = vis.imshow_cls_result(
+        image, result, out_file=tmp_filename, show=False)
+    assert osp.isfile(tmp_filename)
+    assert image.shape == out_image.shape[:2]
+    os.remove(tmp_filename)
+
+    # test show=True
+    image = np.ones((10, 10, 3), np.uint8)
+    result = {'pred_label': 1, 'pred_class': 'bird', 'pred_score': 0.98}
+
+    def save_args(*args, **kwargs):
+        args_list = ['args']
+        args_list += [
+            str(arg) for arg in args if isinstance(arg, (str, bool, int))
+        ]
+        args_list += [
+            f'{k}-{v}' for k, v in kwargs.items()
+            if isinstance(v, (str, bool, int))
+        ]
+        out_path = osp.join(tmp_dir, '_'.join(args_list))
+        with open(out_path, 'w') as f:
+            f.write('test')
+
+    with patch('matplotlib.pyplot.show', save_args), \
+            patch('matplotlib.pyplot.pause', save_args):
+        vis.imshow_cls_result(image, result, show=True, wait_time=5)
+        assert osp.exists(osp.join(tmp_dir, 'args_block-False'))
+        assert osp.exists(osp.join(tmp_dir, 'args_5'))
+
+        vis.imshow_cls_result(image, result, show=True, wait_time=0)
+        assert osp.exists(osp.join(tmp_dir, 'args'))
+
+    shutil.rmtree(tmp_dir)


### PR DESCRIPTION
## Motivation

Now, our `show_result_pyplot` doesn't support `wait_time`. And it uses OpenCV as the `imshow` backend, which may cause some problems, refers to https://github.com/open-mmlab/mmdetection/pull/4389

## Modification

Modify the visualization APIs and code structure as mmdet style.

## BC-breaking (Optional)

No

## Use cases (Optional)

Use demo as example:
```shell
python demo/image_demo.py demo/demo.JPEG config/resnet/resnet50_b32x8_imagenet.py resnet50.pth
```
### Previous version demo
![result2](https://user-images.githubusercontent.com/26739999/130023663-b280b37a-bd3b-4ecb-ad54-2ff59aaa00fc.png)

### Current version demo
![result](https://user-images.githubusercontent.com/26739999/130026310-675b916a-7dcd-4e44-aada-3b76d3461669.png)

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
