### PR TITLE
[Enhance] Improve downstream repositories compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,14 +105,14 @@ venv.bak/
 .mypy_cache/
 
 # custom
-data
+/data
 .vscode
 .idea
 *.pkl
 *.pkl.json
 *.log.json
-work_dirs/
-mmcls/.mim
+/work_dirs
+/mmcls/.mim
 
 # Pytorch
 *.pth

--- a/configs/_base_/models/swin_transformer/base_224.py
+++ b/configs/_base_/models/swin_transformer/base_224.py
@@ -3,7 +3,7 @@ model = dict(
     type='ImageClassifier',
     backbone=dict(
         type='SwinTransformer', arch='base', img_size=224, drop_path_rate=0.5),
-    neck=dict(type='GlobalAveragePooling', dim=1),
+    neck=dict(type='GlobalAveragePooling'),
     head=dict(
         type='LinearClsHead',
         num_classes=1000,

--- a/configs/_base_/models/swin_transformer/base_384.py
+++ b/configs/_base_/models/swin_transformer/base_384.py
@@ -7,7 +7,7 @@ model = dict(
         arch='base',
         img_size=384,
         stage_cfgs=dict(block_cfgs=dict(window_size=12))),
-    neck=dict(type='GlobalAveragePooling', dim=1),
+    neck=dict(type='GlobalAveragePooling'),
     head=dict(
         type='LinearClsHead',
         num_classes=1000,

--- a/configs/_base_/models/swin_transformer/large_224.py
+++ b/configs/_base_/models/swin_transformer/large_224.py
@@ -3,7 +3,7 @@
 model = dict(
     type='ImageClassifier',
     backbone=dict(type='SwinTransformer', arch='large', img_size=224),
-    neck=dict(type='GlobalAveragePooling', dim=1),
+    neck=dict(type='GlobalAveragePooling'),
     head=dict(
         type='LinearClsHead',
         num_classes=1000,

--- a/configs/_base_/models/swin_transformer/large_384.py
+++ b/configs/_base_/models/swin_transformer/large_384.py
@@ -7,7 +7,7 @@ model = dict(
         arch='large',
         img_size=384,
         stage_cfgs=dict(block_cfgs=dict(window_size=12))),
-    neck=dict(type='GlobalAveragePooling', dim=1),
+    neck=dict(type='GlobalAveragePooling'),
     head=dict(
         type='LinearClsHead',
         num_classes=1000,

--- a/configs/_base_/models/swin_transformer/small_224.py
+++ b/configs/_base_/models/swin_transformer/small_224.py
@@ -4,7 +4,7 @@ model = dict(
     backbone=dict(
         type='SwinTransformer', arch='small', img_size=224,
         drop_path_rate=0.3),
-    neck=dict(type='GlobalAveragePooling', dim=1),
+    neck=dict(type='GlobalAveragePooling'),
     head=dict(
         type='LinearClsHead',
         num_classes=1000,

--- a/configs/_base_/models/swin_transformer/tiny_224.py
+++ b/configs/_base_/models/swin_transformer/tiny_224.py
@@ -3,7 +3,7 @@ model = dict(
     type='ImageClassifier',
     backbone=dict(
         type='SwinTransformer', arch='tiny', img_size=224, drop_path_rate=0.2),
-    neck=dict(type='GlobalAveragePooling', dim=1),
+    neck=dict(type='GlobalAveragePooling'),
     head=dict(
         type='LinearClsHead',
         num_classes=1000,

--- a/mmcls/models/backbones/alexnet.py
+++ b/mmcls/models/backbones/alexnet.py
@@ -53,4 +53,4 @@ class AlexNet(BaseBackbone):
             x = x.view(x.size(0), 256 * 6 * 6)
             x = self.classifier(x)
 
-        return x
+        return (x, )

--- a/mmcls/models/backbones/lenet.py
+++ b/mmcls/models/backbones/lenet.py
@@ -39,4 +39,4 @@ class LeNet5(BaseBackbone):
         if self.num_classes > 0:
             x = self.classifier(x.squeeze())
 
-        return x
+        return (x, )

--- a/mmcls/models/backbones/mobilenet_v2.py
+++ b/mmcls/models/backbones/mobilenet_v2.py
@@ -243,10 +243,7 @@ class MobileNetV2(BaseBackbone):
             if i in self.out_indices:
                 outs.append(x)
 
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+        return tuple(outs)
 
     def _freeze_stages(self):
         if self.frozen_stages >= 0:

--- a/mmcls/models/backbones/mobilenet_v3.py
+++ b/mmcls/models/backbones/mobilenet_v3.py
@@ -177,10 +177,7 @@ class MobileNetV3(BaseBackbone):
             if i in self.out_indices:
                 outs.append(x)
 
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+        return tuple(outs)
 
     def _freeze_stages(self):
         for i in range(0, self.frozen_stages + 1):

--- a/mmcls/models/backbones/regnet.py
+++ b/mmcls/models/backbones/regnet.py
@@ -309,7 +309,4 @@ class RegNet(ResNet):
             if i in self.out_indices:
                 outs.append(x)
 
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+        return tuple(outs)

--- a/mmcls/models/backbones/resnet.py
+++ b/mmcls/models/backbones/resnet.py
@@ -624,10 +624,7 @@ class ResNet(BaseBackbone):
             x = res_layer(x)
             if i in self.out_indices:
                 outs.append(x)
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+        return tuple(outs)
 
     def train(self, mode=True):
         super(ResNet, self).train(mode)

--- a/mmcls/models/backbones/resnet_cifar.py
+++ b/mmcls/models/backbones/resnet_cifar.py
@@ -78,7 +78,4 @@ class ResNet_CIFAR(ResNet):
             x = res_layer(x)
             if i in self.out_indices:
                 outs.append(x)
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+        return tuple(outs)

--- a/mmcls/models/backbones/shufflenet_v1.py
+++ b/mmcls/models/backbones/shufflenet_v1.py
@@ -310,10 +310,7 @@ class ShuffleNetV1(BaseBackbone):
             if i in self.out_indices:
                 outs.append(x)
 
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+        return tuple(outs)
 
     def train(self, mode=True):
         super(ShuffleNetV1, self).train(mode)

--- a/mmcls/models/backbones/shufflenet_v2.py
+++ b/mmcls/models/backbones/shufflenet_v2.py
@@ -286,10 +286,7 @@ class ShuffleNetV2(BaseBackbone):
             if i in self.out_indices:
                 outs.append(x)
 
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+        return tuple(outs)
 
     def train(self, mode=True):
         super(ShuffleNetV2, self).train(mode)

--- a/mmcls/models/backbones/timm_backbone.py
+++ b/mmcls/models/backbones/timm_backbone.py
@@ -54,4 +54,4 @@ class TIMMBackbone(BaseBackbone):
 
     def forward(self, x):
         features = self.timm_model.forward_features(x)
-        return features
+        return (features, )

--- a/mmcls/models/backbones/vgg.py
+++ b/mmcls/models/backbones/vgg.py
@@ -163,10 +163,8 @@ class VGG(BaseBackbone):
             x = x.view(x.size(0), -1)
             x = self.classifier(x)
             outs.append(x)
-        if len(outs) == 1:
-            return outs[0]
-        else:
-            return tuple(outs)
+
+        return tuple(outs)
 
     def _freeze_stages(self):
         vgg_layers = getattr(self, self.module_name)

--- a/mmcls/models/classifiers/image.py
+++ b/mmcls/models/classifiers/image.py
@@ -124,4 +124,17 @@ class ImageClassifier(BaseClassifier):
     def simple_test(self, img, img_metas):
         """Test without augmentation."""
         x = self.extract_feat(img)
-        return self.head.simple_test(x)
+
+        try:
+            res = self.head.simple_test(x)
+        except TypeError as e:
+            if 'not tuple' in str(e) and self.return_tuple:
+                return TypeError(
+                    'Seems the head cannot handle tuple input. We have '
+                    'changed all backbones\' output to a tuple. Please '
+                    'update your custom head\'s forward function. '
+                    'Temporarily, you can set "return_tuple=False" in '
+                    'your backbone config to disable this feature.')
+            raise e
+
+        return res

--- a/mmcls/models/classifiers/image.py
+++ b/mmcls/models/classifiers/image.py
@@ -24,7 +24,14 @@ class ImageClassifier(BaseClassifier):
                 key, please consider using init_cfg')
             self.init_cfg = dict(type='Pretrained', checkpoint=pretrained)
 
+        return_tuple = backbone.pop('return_tuple', True)
         self.backbone = build_backbone(backbone)
+        if return_tuple is False:
+            warnings.warn(
+                'The `return_tuple` is a temporary arg, we will force to '
+                'return tuple in the future. Please handle tuple in your '
+                'custom neck or head.', DeprecationWarning)
+        self.return_tuple = return_tuple
 
         if neck is not None:
             self.neck = build_neck(neck)
@@ -64,6 +71,17 @@ class ImageClassifier(BaseClassifier):
     def extract_feat(self, img):
         """Directly extract features from the backbone + neck."""
         x = self.backbone(img)
+        if self.return_tuple:
+            if not isinstance(x, tuple):
+                x = (x, )
+                warnings.simplefilter('once')
+                warnings.warn(
+                    'We will force all backbones to return a tuple in the '
+                    'future. Please check your backbone and wrap the output '
+                    'as a tuple.', DeprecationWarning)
+        else:
+            if isinstance(x, tuple):
+                x = x[-1]
         if self.with_neck:
             x = self.neck(x)
         return x
@@ -87,7 +105,18 @@ class ImageClassifier(BaseClassifier):
         x = self.extract_feat(img)
 
         losses = dict()
-        loss = self.head.forward_train(x, gt_label)
+        try:
+            loss = self.head.forward_train(x, gt_label)
+        except TypeError as e:
+            if 'not tuple' in str(e) and self.return_tuple:
+                return TypeError(
+                    'Seems the head cannot handle tuple input. We have '
+                    'changed all backbones\' output to a tuple. Please '
+                    'update your custom head\'s forward function. '
+                    'Temporarily, you can set "return_tuple=False" in '
+                    'your backbone config to disable this feature.')
+            raise e
+
         losses.update(loss)
 
         return losses
@@ -95,7 +124,4 @@ class ImageClassifier(BaseClassifier):
     def simple_test(self, img, img_metas):
         """Test without augmentation."""
         x = self.extract_feat(img)
-        x_dims = len(x.shape)
-        if x_dims == 1:
-            x.unsqueeze_(0)
         return self.head.simple_test(x)

--- a/mmcls/models/heads/cls_head.py
+++ b/mmcls/models/heads/cls_head.py
@@ -56,11 +56,15 @@ class ClsHead(BaseHead):
         return losses
 
     def forward_train(self, cls_score, gt_label):
+        if isinstance(cls_score, tuple):
+            cls_score = cls_score[-1]
         losses = self.loss(cls_score, gt_label)
         return losses
 
     def simple_test(self, cls_score):
         """Test without augmentation."""
+        if isinstance(cls_score, tuple):
+            cls_score = cls_score[-1]
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None

--- a/mmcls/models/heads/linear_head.py
+++ b/mmcls/models/heads/linear_head.py
@@ -35,9 +35,11 @@ class LinearClsHead(ClsHead):
 
         self.fc = nn.Linear(self.in_channels, self.num_classes)
 
-    def simple_test(self, img):
+    def simple_test(self, x):
         """Test without augmentation."""
-        cls_score = self.fc(img)
+        if isinstance(x, tuple):
+            x = x[-1]
+        cls_score = self.fc(x)
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.softmax(cls_score, dim=1) if cls_score is not None else None
@@ -45,6 +47,8 @@ class LinearClsHead(ClsHead):
         return self.post_process(pred)
 
     def forward_train(self, x, gt_label):
+        if isinstance(x, tuple):
+            x = x[-1]
         cls_score = self.fc(x)
         losses = self.loss(cls_score, gt_label)
         return losses

--- a/mmcls/models/heads/multi_label_head.py
+++ b/mmcls/models/heads/multi_label_head.py
@@ -41,14 +41,18 @@ class MultiLabelClsHead(BaseHead):
         return losses
 
     def forward_train(self, cls_score, gt_label):
+        if isinstance(cls_score, tuple):
+            cls_score = cls_score[-1]
         gt_label = gt_label.type_as(cls_score)
         losses = self.loss(cls_score, gt_label)
         return losses
 
-    def simple_test(self, cls_score):
-        if isinstance(cls_score, list):
-            cls_score = sum(cls_score) / float(len(cls_score))
-        pred = F.sigmoid(cls_score) if cls_score is not None else None
+    def simple_test(self, x):
+        if isinstance(x, tuple):
+            x = x[-1]
+        if isinstance(x, list):
+            x = sum(x) / float(len(x))
+        pred = F.sigmoid(x) if x is not None else None
 
         return self.post_process(pred)
 

--- a/mmcls/models/heads/multi_label_linear_head.py
+++ b/mmcls/models/heads/multi_label_linear_head.py
@@ -40,14 +40,18 @@ class MultiLabelLinearClsHead(MultiLabelClsHead):
         self.fc = nn.Linear(self.in_channels, self.num_classes)
 
     def forward_train(self, x, gt_label):
+        if isinstance(x, tuple):
+            x = x[-1]
         gt_label = gt_label.type_as(x)
         cls_score = self.fc(x)
         losses = self.loss(cls_score, gt_label)
         return losses
 
-    def simple_test(self, img):
+    def simple_test(self, x):
         """Test without augmentation."""
-        cls_score = self.fc(img)
+        if isinstance(x, tuple):
+            x = x[-1]
+        cls_score = self.fc(x)
         if isinstance(cls_score, list):
             cls_score = sum(cls_score) / float(len(cls_score))
         pred = F.sigmoid(cls_score) if cls_score is not None else None

--- a/mmcls/models/heads/stacked_head.py
+++ b/mmcls/models/heads/stacked_head.py
@@ -114,9 +114,11 @@ class StackedLinearClsHead(ClsHead):
     def init_weights(self):
         self.layers.init_weights()
 
-    def simple_test(self, img):
+    def simple_test(self, x):
         """Test without augmentation."""
-        cls_score = img
+        if isinstance(x, tuple):
+            x = x[-1]
+        cls_score = x
         for layer in self.layers:
             cls_score = layer(cls_score)
         if isinstance(cls_score, list):
@@ -126,6 +128,8 @@ class StackedLinearClsHead(ClsHead):
         return self.post_process(pred)
 
     def forward_train(self, x, gt_label):
+        if isinstance(x, tuple):
+            x = x[-1]
         cls_score = x
         for layer in self.layers:
             cls_score = layer(cls_score)

--- a/tests/data/retinanet.py
+++ b/tests/data/retinanet.py
@@ -1,3 +1,6 @@
+# small RetinaNet
+num_classes=3
+
 # model settings
 model = dict(
     type='RetinaNet',
@@ -20,9 +23,9 @@ model = dict(
         num_outs=5),
     bbox_head=dict(
         type='RetinaHead',
-        num_classes=80,
+        num_classes=num_classes,
         in_channels=256,
-        stacked_convs=4,
+        stacked_convs=1,
         feat_channels=256,
         anchor_generator=dict(
             type='AnchorGenerator',
@@ -58,3 +61,22 @@ model = dict(
         score_thr=0.05,
         nms=dict(type='nms', iou_threshold=0.5),
         max_per_img=100))
+
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(1333, 800),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(test=dict(pipeline=test_pipeline))

--- a/tests/test_downstream/test_mmdet_inference.py
+++ b/tests/test_downstream/test_mmdet_inference.py
@@ -1,4 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import numpy as np
+from mmcv import Config
+from mmdet.apis import inference_detector
 from mmdet.models import build_detector
 
 from mmcls.models import (MobileNetV2, MobileNetV3, RegNet, ResNeSt, ResNet,
@@ -10,31 +13,46 @@ backbone_configs = dict(
             type='mmcls.MobileNetV2',
             widen_factor=1.0,
             norm_cfg=dict(type='GN', num_groups=2, requires_grad=True),
-            out_indices=(4, 7))),
+            out_indices=(4, 7)),
+        out_channels=[96, 1280]),
     mobilenetv3=dict(
         backbone=dict(
             type='mmcls.MobileNetV3',
             norm_cfg=dict(type='GN', num_groups=2, requires_grad=True),
-            out_indices=range(7, 12))),
-    regnet=dict(backbone=dict(type='mmcls.RegNet', arch='regnetx_400mf')),
+            out_indices=range(7, 12)),
+        out_channels=[48, 48, 96, 96, 96]),
+    regnet=dict(
+        backbone=dict(type='mmcls.RegNet', arch='regnetx_400mf'),
+        out_channels=384),
     resnext=dict(
         backbone=dict(
-            type='mmcls.ResNeXt', depth=50, groups=32, width_per_group=4)),
-    resnet=dict(backbone=dict(type='mmcls.ResNet', depth=50)),
-    seresnet=dict(backbone=dict(type='mmcls.SEResNet', depth=50)),
+            type='mmcls.ResNeXt', depth=50, groups=32, width_per_group=4),
+        out_channels=2048),
+    resnet=dict(
+        backbone=dict(type='mmcls.ResNet', depth=50), out_channels=2048),
+    seresnet=dict(
+        backbone=dict(type='mmcls.SEResNet', depth=50), out_channels=2048),
     seresnext=dict(
         backbone=dict(
-            type='mmcls.SEResNeXt', depth=50, groups=32, width_per_group=4)),
+            type='mmcls.SEResNeXt', depth=50, groups=32, width_per_group=4),
+        out_channels=2048),
     resnest=dict(
         backbone=dict(
             type='mmcls.ResNeSt',
             depth=50,
             radix=2,
             reduction_factor=4,
-            out_indices=(0, 1, 2, 3))),
+            out_indices=(0, 1, 2, 3)),
+        out_channels=[256, 512, 1024, 2048]),
     swin=dict(
         backbone=dict(
-            type='mmcls.SwinTransformer', arch='small', drop_path_rate=0.2)))
+            type='mmcls.SwinTransformer',
+            arch='small',
+            drop_path_rate=0.2,
+            img_size=800,
+            out_indices=(2, 3),
+            auto_pad=True),
+        out_channels=[384, 768]))
 
 module_mapping = {
     'mobilenetv2': MobileNetV2,
@@ -50,12 +68,29 @@ module_mapping = {
 
 
 def test_mmdet_inference():
-    from mmcv import Config
     config_path = './tests/data/retinanet.py'
-    config = Config.fromfile(config_path)
+    rng = np.random.RandomState(0)
+    img1 = rng.rand(100, 100, 3)
 
     for module_name, backbone_config in backbone_configs.items():
+        config = Config.fromfile(config_path)
         config.model.backbone = backbone_config['backbone']
+        out_channels = backbone_config['out_channels']
+        if isinstance(out_channels, int):
+            config.model.neck = None
+            config.model.bbox_head.in_channels = out_channels
+            anchor_generator = config.model.bbox_head.anchor_generator
+            anchor_generator.strides = anchor_generator.strides[:1]
+        else:
+            config.model.neck.in_channels = out_channels
+
         model = build_detector(config.model)
         module = module_mapping[module_name]
         assert isinstance(model.backbone, module)
+
+        model.cfg = config
+
+        model.eval()
+        print(module_name)
+        result = inference_detector(model, img1)
+        assert len(result) == config.num_classes

--- a/tests/test_models/test_backbones/test_mobilenet_v2.py
+++ b/tests/test_models/test_backbones/test_mobilenet_v2.py
@@ -155,7 +155,8 @@ def test_mobilenetv2_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size((1, 2560, 7, 7))
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size((1, 2560, 7, 7))
 
     # Test MobileNetV2 forward with out_indices=None
     model = MobileNetV2(widen_factor=1.0)
@@ -164,7 +165,8 @@ def test_mobilenetv2_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size((1, 1280, 7, 7))
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size((1, 1280, 7, 7))
 
     # Test MobileNetV2 forward with dict(type='ReLU')
     model = MobileNetV2(

--- a/tests/test_models/test_backbones/test_mobilenet_v3.py
+++ b/tests/test_models/test_backbones/test_mobilenet_v3.py
@@ -158,7 +158,8 @@ def test_mobilenetv3_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size([1, 16, 112, 112])
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size([1, 16, 112, 112])
 
     # Test MobileNetV3 with checkpoint forward
     model = MobileNetV3(with_cp=True)
@@ -170,4 +171,5 @@ def test_mobilenetv3_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size([1, 576, 7, 7])
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size([1, 576, 7, 7])

--- a/tests/test_models/test_backbones/test_regnet.py
+++ b/tests/test_models/test_backbones/test_regnet.py
@@ -45,8 +45,9 @@ def test_regnet_backbone(arch_name, arch, out_channels):
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert isinstance(feat, torch.Tensor)
-    assert feat.shape == (1, out_channels[-1], 7, 7)
+    assert len(feat) == 1
+    assert isinstance(feat[0], torch.Tensor)
+    assert feat[0].shape == (1, out_channels[-1], 7, 7)
 
     # output feature map of all stages
     model = RegNet(arch_name, out_indices=(0, 1, 2, 3))
@@ -70,8 +71,9 @@ def test_custom_arch(arch_name, arch, out_channels):
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert isinstance(feat, torch.Tensor)
-    assert feat.shape == (1, out_channels[-1], 7, 7)
+    assert len(feat) == 1
+    assert isinstance(feat[0], torch.Tensor)
+    assert feat[0].shape == (1, out_channels[-1], 7, 7)
 
     # output feature map of all stages
     model = RegNet(arch, out_indices=(0, 1, 2, 3))

--- a/tests/test_models/test_backbones/test_resnet.py
+++ b/tests/test_models/test_backbones/test_resnet.py
@@ -475,7 +475,8 @@ def test_resnet():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == (1, 2048, 7, 7)
+    assert len(feat) == 1
+    assert feat[0].shape == (1, 2048, 7, 7)
 
     # Test ResNet50 with checkpoint forward
     model = ResNet(50, out_indices=(0, 1, 2, 3), with_cp=True)

--- a/tests/test_models/test_backbones/test_resnext.py
+++ b/tests/test_models/test_backbones/test_resnext.py
@@ -57,4 +57,5 @@ def test_resnext():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size([1, 2048, 7, 7])
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size([1, 2048, 7, 7])

--- a/tests/test_models/test_backbones/test_seresnet.py
+++ b/tests/test_models/test_backbones/test_seresnet.py
@@ -211,7 +211,8 @@ def test_seresnet():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size([1, 2048, 7, 7])
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size([1, 2048, 7, 7])
 
     # Test SEResNet50 with checkpoint forward
     model = SEResNet(50, out_indices=(0, 1, 2, 3), with_cp=True)

--- a/tests/test_models/test_backbones/test_seresnext.py
+++ b/tests/test_models/test_backbones/test_seresnext.py
@@ -70,4 +70,5 @@ def test_seresnext():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size([1, 2048, 7, 7])
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size([1, 2048, 7, 7])

--- a/tests/test_models/test_backbones/test_shufflenet_v1.py
+++ b/tests/test_models/test_backbones/test_shufflenet_v1.py
@@ -228,8 +228,9 @@ def test_shufflenetv1_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert isinstance(feat, torch.Tensor)
-    assert feat.shape == torch.Size((1, 960, 7, 7))
+    assert len(feat) == 1
+    assert isinstance(feat[0], torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 960, 7, 7))
 
     # Test ShuffleNetV1 forward with checkpoint forward
     model = ShuffleNetV1(groups=3, with_cp=True)

--- a/tests/test_models/test_backbones/test_shufflenet_v2.py
+++ b/tests/test_models/test_backbones/test_shufflenet_v2.py
@@ -179,8 +179,9 @@ def test_shufflenetv2_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert isinstance(feat, torch.Tensor)
-    assert feat.shape == torch.Size((1, 464, 7, 7))
+    assert len(feat) == 1
+    assert isinstance(feat[0], torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 464, 7, 7))
 
     # Test ShuffleNetV2 forward with layers 1 2 forward
     model = ShuffleNetV2(widen_factor=1.0, out_indices=(1, 2))

--- a/tests/test_models/test_backbones/test_swin_transformer.py
+++ b/tests/test_models/test_backbones/test_swin_transformer.py
@@ -1,14 +1,17 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os
+import tempfile
 from math import ceil
 
 import numpy as np
 import pytest
 import torch
+from mmcv.runner import load_checkpoint, save_checkpoint
 
 from mmcls.models.backbones import SwinTransformer
 
 
-def test_swin_transformer():
+def test_assertion():
     """Test Swin Transformer backbone."""
     with pytest.raises(AssertionError):
         # Swin Transformer arch string should be in
@@ -19,6 +22,8 @@ def test_swin_transformer():
         # 'depths' and 'num_head' keys.
         SwinTransformer(arch=dict(embed_dims=96, depths=[2, 2, 18, 2]))
 
+
+def test_forward():
     # Test tiny arch forward
     model = SwinTransformer(arch='Tiny')
     model.init_weights()
@@ -26,7 +31,8 @@ def test_swin_transformer():
 
     imgs = torch.randn(1, 3, 224, 224)
     output = model(imgs)
-    assert output.shape == (1, 768, 49)
+    assert len(output) == 1
+    assert output[0].shape == (1, 768, 7, 7)
 
     # Test small arch forward
     model = SwinTransformer(arch='small')
@@ -35,7 +41,8 @@ def test_swin_transformer():
 
     imgs = torch.randn(1, 3, 224, 224)
     output = model(imgs)
-    assert output.shape == (1, 768, 49)
+    assert len(output) == 1
+    assert output[0].shape == (1, 768, 7, 7)
 
     # Test base arch forward
     model = SwinTransformer(arch='B')
@@ -44,7 +51,8 @@ def test_swin_transformer():
 
     imgs = torch.randn(1, 3, 224, 224)
     output = model(imgs)
-    assert output.shape == (1, 1024, 49)
+    assert len(output) == 1
+    assert output[0].shape == (1, 1024, 7, 7)
 
     # Test large arch forward
     model = SwinTransformer(arch='l')
@@ -53,7 +61,8 @@ def test_swin_transformer():
 
     imgs = torch.randn(1, 3, 224, 224)
     output = model(imgs)
-    assert output.shape == (1, 1536, 49)
+    assert len(output) == 1
+    assert output[0].shape == (1, 1536, 7, 7)
 
     # Test base arch with window_size=12, image_size=384
     model = SwinTransformer(
@@ -65,19 +74,18 @@ def test_swin_transformer():
 
     imgs = torch.randn(1, 3, 384, 384)
     output = model(imgs)
-    assert output.shape == (1, 1024, 144)
+    assert len(output) == 1
+    assert output[0].shape == (1, 1024, 12, 12)
 
+
+def test_structure():
     # Test small with use_abs_pos_embed = True
     model = SwinTransformer(arch='small', use_abs_pos_embed=True)
-    model.init_weights()
-    model.train()
-
     assert model.absolute_pos_embed.shape == (1, 3136, 96)
 
     # Test small with use_abs_pos_embed = False
-    with pytest.raises(AttributeError):
-        model = SwinTransformer(arch='small', use_abs_pos_embed=False)
-        model.absolute_pos_embed
+    model = SwinTransformer(arch='small', use_abs_pos_embed=False)
+    assert not hasattr(model, 'absolute_pos_embed')
 
     # Test small with auto_pad = True
     model = SwinTransformer(
@@ -88,10 +96,6 @@ def test_swin_transformer():
             downsample_cfg={
                 'kernel_size': (3, 2),
             }))
-    model.init_weights()
-    model.train()
-
-    imgs = torch.randn(1, 3, 224, 224)
 
     # stage 1
     input_h = int(224 / 4 / 3)
@@ -143,3 +147,22 @@ def test_swin_transformer():
             assert np.isclose(block.ffn.dropout_layer.drop_prob, expect_prob)
             assert np.isclose(block.attn.drop.drop_prob, expect_prob)
             pos += 1
+
+
+def test_load_checkpoint():
+    model = SwinTransformer(arch='tiny')
+    ckpt_path = os.path.join(tempfile.gettempdir(), 'ckpt.pth')
+
+    assert model._version == 2
+
+    # test load v2 checkpoint
+    save_checkpoint(model, ckpt_path)
+    load_checkpoint(model, ckpt_path, strict=True)
+
+    # test load v1 checkpoint
+    setattr(model, 'norm', model.norm3)
+    model._version = 1
+    del model.norm3
+    save_checkpoint(model, ckpt_path)
+    model = SwinTransformer(arch='tiny')
+    load_checkpoint(model, ckpt_path, strict=True)

--- a/tests/test_models/test_backbones/test_timm_backbone.py
+++ b/tests/test_models/test_backbones/test_timm_backbone.py
@@ -29,7 +29,8 @@ def test_timm_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size((1, 512, 7, 7))
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size((1, 512, 7, 7))
 
     # Test efficientnet_b1 with pretrained weights
     model = TIMMBackbone(model_name='efficientnet_b1', pretrained=True)
@@ -38,4 +39,5 @@ def test_timm_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size((1, 1280, 7, 7))
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size((1, 1280, 7, 7))

--- a/tests/test_models/test_backbones/test_vgg.py
+++ b/tests/test_models/test_backbones/test_vgg.py
@@ -125,7 +125,8 @@ def test_vgg():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == (1, 512, 7, 7)
+    assert len(feat) == 1
+    assert feat[0].shape == (1, 512, 7, 7)
 
     # Test VGG19 with classification score out forward
     model = VGG(19, num_classes=10)
@@ -134,4 +135,5 @@ def test_vgg():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == (1, 10)
+    assert len(feat) == 1
+    assert feat[0].shape == (1, 10)

--- a/tests/test_models/test_classifiers.py
+++ b/tests/test_models/test_classifiers.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 import numpy as np
 import pytest
 import torch
+from mmcv import ConfigDict
+from mmcv.runner.base_module import BaseModule
 
 from mmcls.models import CLASSIFIERS
 from mmcls.models.classifiers import ImageClassifier
@@ -239,3 +241,56 @@ def test_image_classifier_with_augments():
 
     losses = img_classifier.forward_train(imgs, label)
     assert losses['loss'].item() > 0
+
+
+def test_image_classifier_return_tuple():
+    model_cfg = ConfigDict(
+        type='ImageClassifier',
+        backbone=dict(
+            type='ResNet_CIFAR',
+            depth=50,
+            num_stages=4,
+            out_indices=(3, ),
+            style='pytorch',
+            return_tuple=False),
+        head=dict(
+            type='LinearClsHead',
+            num_classes=10,
+            in_channels=2048,
+            loss=dict(type='CrossEntropyLoss')))
+
+    imgs = torch.randn(16, 3, 32, 32)
+
+    model_cfg_ = deepcopy(model_cfg)
+    with pytest.warns(DeprecationWarning):
+        model = CLASSIFIERS.build(model_cfg_)
+
+    # test backbone return tensor
+    feat = model.extract_feat(imgs)
+    assert isinstance(feat, torch.Tensor)
+
+    # test backbone return tuple
+    model_cfg_ = deepcopy(model_cfg)
+    model_cfg_.backbone.return_tuple = True
+    model = CLASSIFIERS.build(model_cfg_)
+
+    feat = model.extract_feat(imgs)
+    assert isinstance(feat, tuple)
+
+    # test warning if backbone return tensor
+    class ToyBackbone(BaseModule):
+
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 16, 3)
+
+        def forward(self, x):
+            return self.conv(x)
+
+    model_cfg_ = deepcopy(model_cfg)
+    model_cfg_.backbone.return_tuple = True
+    model = CLASSIFIERS.build(model_cfg_)
+    model.backbone = ToyBackbone()
+
+    with pytest.warns(DeprecationWarning):
+        model.extract_feat(imgs)


### PR DESCRIPTION
## Motivation

Now, the return value of `forward` of backbones can be `torch.Tensor` or `tuple`, which depends on `out_indices`. That's not compatible with downstream repos.

And some backbones don't support the `out_indices` option.

## Modification

1. Force all backbones to return tuple in `forward` function and add tuple support in all heads.
2. Support `out_indices` in the swin-transformer. ViT support will be added in #395.

## BC-breaking (Optional)

Yes, if users' custom head doesn't support tuples, the program will break. I have added warning info about it when the program detects it.
And users can specify `return_tuple=False` to disable this new feature temporarily.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
