### PR TITLE
[Docs] Add `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "OpenMMLab's Image Classification Toolbox and Benchmark"
+authors:
+  - name: "MMClassification Contributors"
+version: 0.15.0
+date-released: 2020-07-09
+repository-code: "https://github.com/open-mmlab/mmclassification"
+license: Apache-2.0

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ def parse_requirements(fname='requirements.txt', with_version=True):
     return packages
 
 
-def add_mim_extention():
+def add_mim_extension():
     """Add extra files that are required to support MIM into the package.
 
     These files will be added by creating a symlink to the originals if the
@@ -144,7 +144,7 @@ def add_mim_extention():
 
 
 if __name__ == '__main__':
-    add_mim_extention()
+    add_mim_extension()
     setup(
         name='mmcls',
         version=get_version(),

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
         description='OpenMMLab Image Classification Toolbox and Benchmark',
         long_description=readme(),
         long_description_content_type='text/markdown',
-        author='OpenMMLab',
+        author='MMClassification Contributors',
         author_email='openmmlab@gmail.com',
         keywords='computer vision, image classification',
         url='https://github.com/open-mmlab/mmclassification',


### PR DESCRIPTION
## Motivation

Github provides the citation option now, and to use it, we need to add `CITATION.cff`.

## Modification

As the title.

And fix some small typo in `setup.py`, change `author` in `setup.py`. Refers to https://github.com/open-mmlab/mmtracking/pull/253

## Use cases

![深度截图_选择区域_20210901135002](https://user-images.githubusercontent.com/26739999/131618843-e3d897d5-1699-4dab-8d0e-c3b1d6687830.png)
The auto generated bib file:
```bib
@misc{MMClassification_Contributors_OpenMMLabs_Image_Classification_2020,
  author = {{MMClassification Contributors}},
  month = {7},
  title = {{OpenMMLab's Image Classification Toolbox and Benchmark}},
  url = {https://github.com/open-mmlab/mmclassification},
  year = {2020}
}
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
