### PR TITLE
[Refactor] Fix TnT compatibility and verbose warning.

### DIFF
--- a/mmcls/models/backbones/tnt.py
+++ b/mmcls/models/backbones/tnt.py
@@ -364,4 +364,4 @@ class TNT(BaseBackbone):
             pixel_embed, patch_embed = layer(pixel_embed, patch_embed)
 
         patch_embed = self.norm(patch_embed)
-        return patch_embed[:, 0]
+        return (patch_embed[:, 0], )

--- a/mmcls/models/classifiers/image.py
+++ b/mmcls/models/classifiers/image.py
@@ -6,6 +6,8 @@ from ..builder import CLASSIFIERS, build_backbone, build_head, build_neck
 from ..utils.augment import Augments
 from .base import BaseClassifier
 
+warnings.simplefilter('once')
+
 
 @CLASSIFIERS.register_module()
 class ImageClassifier(BaseClassifier):
@@ -74,7 +76,6 @@ class ImageClassifier(BaseClassifier):
         if self.return_tuple:
             if not isinstance(x, tuple):
                 x = (x, )
-                warnings.simplefilter('once')
                 warnings.warn(
                     'We will force all backbones to return a tuple in the '
                     'future. Please check your backbone and wrap the output '

--- a/tests/test_models/test_backbones/test_tnt.py
+++ b/tests/test_models/test_backbones/test_tnt.py
@@ -29,7 +29,8 @@ def test_tnt_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size((1, 640))
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size((1, 640))
 
     # Test tnt with embed_dims=768
     arch = {
@@ -45,4 +46,5 @@ def test_tnt_backbone():
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
-    assert feat.shape == torch.Size((1, 768))
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size((1, 768))


### PR DESCRIPTION
## Motivation

TnT does not support return tuple now. And the warning in `extract_feat` will show in every call.

## Modification

As the title

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
