### PR TITLE
[Enhance] Support setting `--out-items` in `tools/test.py`. 

### DIFF
--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -67,6 +67,13 @@ def save_imgs(result_dir, folder_name, results, model):
 def main():
     args = parse_args()
 
+    # load test results
+    outputs = mmcv.load(args.result)
+    assert ('pred_score' in outputs and 'pred_class' in outputs
+            and 'pred_label' in outputs), \
+        'No "pred_label", "pred_score" or "pred_class" in result file, ' \
+        'please set "--out-items" in test.py'
+
     cfg = mmcv.Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
@@ -86,8 +93,6 @@ def main():
     gt_labels = list(dataset.get_gt_labels())
     gt_classes = [dataset.CLASSES[x] for x in gt_labels]
 
-    # load test results
-    outputs = mmcv.load(args.result)
     outputs['filename'] = filenames
     outputs['gt_label'] = gt_labels
     outputs['gt_class'] = gt_classes

--- a/tools/analysis_tools/eval_metric.py
+++ b/tools/analysis_tools/eval_metric.py
@@ -41,6 +41,10 @@ def parse_args():
 def main():
     args = parse_args()
 
+    outputs = mmcv.load(args.pkl_results)
+    assert 'class_scores' in outputs, \
+        'No "class_scores" in result file, please set "--out-items" in test.py'
+
     cfg = Config.fromfile(args.config)
     assert args.metrics, (
         'Please specify at least one metric the argument "--metrics".')
@@ -54,7 +58,6 @@ def main():
     cfg.data.test.test_mode = True
 
     dataset = build_dataset(cfg.data.test)
-    outputs = mmcv.load(args.pkl_results)
     pred_score = outputs['class_scores']
 
     kwargs = {} if args.eval_options is None else args.eval_options

--- a/tools/test.py
+++ b/tools/test.py
@@ -28,6 +28,17 @@ def parse_args():
     parser.add_argument('config', help='test config file path')
     parser.add_argument('checkpoint', help='checkpoint file')
     parser.add_argument('--out', help='output result file')
+    out_options = ['class_scores', 'pred_score', 'pred_label', 'pred_class']
+    parser.add_argument(
+        '--out-items',
+        nargs='+',
+        default=['all'],
+        choices=out_options + ['none', 'all'],
+        help='Besides metrics, what items will be included in the output '
+        f'result file. You can choose some of ({", ".join(out_options)}), '
+        'or use "all" to include all above, or use "none" to disable all of '
+        'above. Defaults to output all.',
+        metavar='')
     parser.add_argument(
         '--metrics',
         type=str,
@@ -177,16 +188,22 @@ def main():
             for k, v in eval_results.items():
                 print(f'\n{k} : {v:.2f}')
         if args.out:
-            scores = np.vstack(outputs)
-            pred_score = np.max(scores, axis=1)
-            pred_label = np.argmax(scores, axis=1)
-            pred_class = [CLASSES[lb] for lb in pred_label]
-            results.update({
-                'class_scores': scores,
-                'pred_score': pred_score,
-                'pred_label': pred_label,
-                'pred_class': pred_class
-            })
+            if 'none' not in args.out_items:
+                scores = np.vstack(outputs)
+                pred_score = np.max(scores, axis=1)
+                pred_label = np.argmax(scores, axis=1)
+                pred_class = [CLASSES[lb] for lb in pred_label]
+                res_items = {
+                    'class_scores': scores,
+                    'pred_score': pred_score,
+                    'pred_label': pred_label,
+                    'pred_class': pred_class
+                }
+                if 'all' in args.out_items:
+                    results.update(res_items)
+                else:
+                    for key in args.out_items:
+                        results[key] = res_items[key]
             print(f'\ndumping results to {args.out}')
             mmcv.dump(results, args.out)
 


### PR DESCRIPTION
## Motivation

The out file of our `tools/test.py` includes all detailed information, like class scores, pred_label, pred_score, pred_class of each sample.

As the result, a huge dataset leads to a huge result file, and not all data is necessary.

## Modification

Add an `--out-items` option, users can use it to specify which info should be included in the result file.

## Use cases (Optional)

```shell
python tools/test.py configs/resnet/resnet18_b16x8_cifar10.py ckpt.pth --metrics accuracy --out result.pkl --out-items class_scores pred_label
```
and
```python
>>> import mmcv
>>> res = mmcv.load("./result.pkl")
>>> print(res.keys())
dict_keys(['accuracy_top-1', 'accuracy_top-5', 'class_scores', 'pred_label'])
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
