### PR TITLE
[Fix] Fix format error in `test.py` when metric returns `np.ndarray`

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -182,8 +182,6 @@ def main():
                     v = round(v, 2)
                 else:
                     raise ValueError(f'Unsupport metric type: {type(v)}')
-                else:
-                    v = round(v, 2)
                 print(f'\n{k} : {v}')
         if args.out:
             scores = np.vstack(outputs)

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
+from numbers import Number
 import os
 import warnings
 
@@ -175,7 +176,11 @@ def main():
                                             args.metric_options)
             results.update(eval_results)
             for k, v in eval_results.items():
-                print(f'\n{k} : {v:.2f}')
+                if args.metric_options is not None and not isinstance(v, Number):
+                    v = [round(out, 2) for out in v.tolist()]
+                else:
+                    v = round(v, 2)
+                print(f'\n{k} : {v}')
         if args.out:
             scores = np.vstack(outputs)
             pred_score = np.max(scores, axis=1)

--- a/tools/test.py
+++ b/tools/test.py
@@ -177,7 +177,7 @@ def main():
             results.update(eval_results)
             for k, v in eval_results.items():
                 if isinstance(v, np.ndarray):
-                    v = [round(out, 2), for out in v.tolist()]
+                    v = [round(out, 2) for out in v.tolist()]
                 elif isinstance(v, Number):
                     v = round(v, 2)
                 else:

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
-from numbers import Number
 import os
 import warnings
+from numbers import Number
 
 import mmcv
 import numpy as np

--- a/tools/test.py
+++ b/tools/test.py
@@ -176,8 +176,12 @@ def main():
                                             args.metric_options)
             results.update(eval_results)
             for k, v in eval_results.items():
-                if args.metric_options is not None and not isinstance(v, Number):
-                    v = [round(out, 2) for out in v.tolist()]
+                if isinstance(v, np.ndarray):
+                    v = [round(out, 2), for out in v.tolist()]
+                elif isinstance(v, Number):
+                    v = round(v, 2)
+                else:
+                    raise ValueError(f'Unsupport metric type: {type(v)}')
                 else:
                     v = round(v, 2)
                 print(f'\n{k} : {v}')


### PR DESCRIPTION
## Motivation

Fix the output format error when --metric-options average_mode=none
## Modification

Add metric-options judgment condition
## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
