### PR TITLE
[Fix] Fix num_classes bug in pytorch2onnx.py

### DIFF
--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -61,7 +61,8 @@ def pytorch2onnx(model,
 
     if hasattr(model.head, 'num_classes'):
         num_classes = model.head.num_classes
-    elif hasattr(model.backbone, 'num_classes'):
+    # Some backbones use `num_classes=-1` to disable top classifier.
+    elif getattr(model.backbone, 'num_classes', -1) > 0:
         num_classes = model.backbone.num_classes
     else:
         raise AttributeError('Cannot find "num_classes" in both head and '

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -59,7 +59,14 @@ def pytorch2onnx(model,
     """
     model.cpu().eval()
 
-    num_classes = model.head.num_classes
+    if hasattr(model.head, 'num_classes'):
+        num_classes = model.head.num_classes
+    elif hasattr(model.backbone, 'num_classes'):
+        num_classes = model.backbone.num_classes
+    else:
+        raise AttributeError('Cannot find "num_classes" in both head and '
+                             'backbone, please check the config file.')
+
     mm_inputs = _demo_mm_inputs(input_shape, num_classes)
 
     imgs = mm_inputs.pop('imgs')


### PR DESCRIPTION
## Motivation

Now in `pytorch2onnx.py`, we get `num_classes` from `model.head`. But if models use `ClsHead`, `num_classes` is from `backbone`. Refers to #442

## Modification

Check if `model.head` doesn’t have `num_classes`, try to find it in `model.backbone`.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
