### PR TITLE
Fix `publish_model` bug if no parent of `out_file`.

### DIFF
--- a/tools/convert_models/publish_model.py
+++ b/tools/convert_models/publish_model.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 import datetime
-import os
 import subprocess
+from pathlib import Path
 
 import torch
 from mmcv import digit_version
@@ -44,8 +44,8 @@ def process_checkpoint(in_file, out_file):
 
 def main():
     args = parse_args()
-    out_dir = os.path.dirname(args.out_file)
-    if not os.path.exists(out_dir):
+    out_dir = Path(args.out_file).parent
+    if not out_dir.exists():
         raise ValueError(f'Directory {out_dir} does not exist, '
                          'please generate it manually.')
     process_checkpoint(args.in_file, args.out_file)


### PR DESCRIPTION
## Motivation

Now, we use `os.path.dirname` to get the parent of `out_file`. However, if we use `out_file` like `resnet.pth`, the `os.path.dirname` gets an empty string, and `os.path.exists` gets False.

## Modification

Use `pathlib` to replace `os.path`.

## BC-breaking (Optional)

No

## Use cases (Optional)

No.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
