### PR TITLE
[Fix] Fix a wrong paramter of `get_root_logger` in `apis/train.py`.

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -56,7 +56,7 @@ def train_model(model,
                 timestamp=None,
                 device='cuda',
                 meta=None):
-    logger = get_root_logger(cfg.log_level)
+    logger = get_root_logger()
 
     # prepare data loaders
     dataset = dataset if isinstance(dataset, (list, tuple)) else [dataset]


### PR DESCRIPTION
The get_root_logger(log_file=None, log_level=logging.INFO) function does not needs the string type cfg.log_level as input. This bug does not have negative effect.

## Motivation

refers to issue https://github.com/open-mmlab/mmclassification/issues/485

## Modification

`logger = get_root_logger()`

## BC-breaking (Optional)

-

## Use cases (Optional)

-

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
