### PR TITLE
[Fix] Set the priority of `EvalHook` to "LOW" to avoid a bug of `IterBasedRunner`

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -151,6 +151,9 @@ def train_model(model,
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook
+        # `EvalHook` needs to be executed after `IterTimerHook`.
+        # Otherwise, it will cause a bug if use `IterBasedRunner`.
+        # Refers to https://github.com/open-mmlab/mmcv/issues/1261
         runner.register_hook(
             eval_hook(val_dataloader, **eval_cfg), priority='LOW')
 


### PR DESCRIPTION
## Motivation

If the priority of EvalHook is higher than IterTimerHook, it will cause KeyError: 'data_time' (open-mmlab/mmsegmentation#758, open-mmlab/mmcv#1261).
Since the time key will add to the output of log_buffer after IterTimeHook, the TextLoggerHook will print the time and data_time at the same time.

This PR is based on open-mmlab/mmsegmentation#766 open-mmlab/mmdetection#5882 .

This PR will be useful for models that uses IterBasedRunner.

## Modification

Set the priority of EvalHook to LOW.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
