### PR TITLE
[Fix] Fix bug in `1-benchmark_valid.py` if checkpoint_root is None.

### DIFF
--- a/.dev_scripts/benchmark_regression/1-benchmark_valid.py
+++ b/.dev_scripts/benchmark_regression/1-benchmark_valid.py
@@ -182,12 +182,13 @@ def main(args):
         if args.checkpoint_root is not None:
             root = Path(args.checkpoint_root)
             checkpoint = root / model_info.Weights[len(http_prefix):]
+            checkpoint = str(checkpoint)
         else:
             checkpoint = None
 
         try:
             # build the model from a config file and a checkpoint file
-            result = inference(MMCLS_ROOT / config, str(checkpoint),
+            result = inference(MMCLS_ROOT / config, checkpoint,
                                classes_map[dataset], args)
             result['valid'] = 'PASS'
         except Exception as e:


### PR DESCRIPTION
## Motivation

In `1-benchmark_valid.py`, if `args.checkpoint_root` is None, it will raise an error.

## Modification

Fix the bug.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
