### PR TITLE
[Fix] Remove `DistSamplerSeedHook` if use `IterBasedRunner`.

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -135,7 +135,7 @@ def train_model(model,
         cfg.log_config,
         cfg.get('momentum_config', None),
         custom_hooks_config=cfg.get('custom_hooks', None))
-    if distributed and cfg.runner['type'] != 'IterBasedRunner':
+    if distributed and cfg.runner['type'] == 'EpochBasedRunner':
         runner.register_hook(DistSamplerSeedHook())
 
     # register eval hooks


### PR DESCRIPTION

## Motivation

When using IterBasedRunner, it will raise the `AttributeError: 'IterBasedRunner' object has no attribute 'data_loader'` in DistSamplerSeedHook during the before_epoch.

According to the comments, there is no need to register the DistSamplerSeedHook for IterBasedRunner, so I remove it.

## Modification

see the diff below

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

NO


