### PR TITLE
[Fix] Fix wrong condition judgment in `analyze_logs.py` and prevent empty curve.

### DIFF
--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -57,11 +57,9 @@ def plot_curve(log_dicts, args):
                     f'{args.json_logs[i]} does not contain metric {metric} '
                     f'in train mode')
 
-            if 'mAP' in metric:
-                xs = np.arange(1, max(epochs) + 1)
-                ys = []
-                for epoch in epochs:
-                    ys += log_dict[epoch][metric]
+            if any(m in metric for m in ('mAP', 'accuracy')):
+                xs = epochs
+                ys = [log_dict[e][metric] for e in xs]
                 ax = plt.gca()
                 ax.set_xticks(xs)
                 plt.xlabel('epoch')

--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -73,7 +73,7 @@ def plot_curve(log_dicts, args):
                 for epoch in epochs:
                     iters = log_dict[epoch]['iter']
                     if log_dict[epoch]['mode'][-1] == 'val':
-                        iters = iters[:-1]
+                        iters = iters[:-1] or iters
                     xs.append(
                         np.array(iters) + (epoch - 1) * num_iters_per_epoch)
                     ys.append(np.array(log_dict[epoch][metric][:len(iters)]))

--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -71,7 +71,10 @@ def plot_curve(log_dicts, args):
                 for epoch in epochs:
                     iters = log_dict[epoch]['iter']
                     if log_dict[epoch]['mode'][-1] == 'val':
-                        iters = iters[:-1] or iters
+                        iters = iters[:-1]
+                    assert len(iters) > 0, (
+                        'The training log is empty, please try to reduce the '
+                        'interval of log in config file.')
                     xs.append(
                         np.array(iters) + (epoch - 1) * num_iters_per_epoch)
                     ys.append(np.array(log_dict[epoch][metric][:len(iters)]))


### PR DESCRIPTION
## Motivation

Make `analyze_log.py` works with single validation iteration. Currently, the `analyza_logs.py` use `iters = iters[:-1]` to get rid of the last validation iteration, but in a very small `val` set, there maybe only one validation step. In such case, the `analyze_log.py` won't work, it use print out a blank figure. This PR fixed that. 

## Modification

When there is only one item in the `iters` list, then don't slice it.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
