### PR TITLE
[Feature] Support positive weights in BCE.

### DIFF
--- a/mmcls/models/losses/cross_entropy_loss.py
+++ b/mmcls/models/losses/cross_entropy_loss.py
@@ -11,8 +11,7 @@ def cross_entropy(pred,
                   weight=None,
                   reduction='mean',
                   avg_factor=None,
-                  class_weight=None,
-                  pos_weight=None):
+                  class_weight=None):
     """Calculate the CrossEntropy loss.
 
     Args:
@@ -46,8 +45,7 @@ def soft_cross_entropy(pred,
                        weight=None,
                        reduction='mean',
                        class_weight=None,
-                       avg_factor=None,
-                       pos_weight=None):
+                       avg_factor=None):
     """Calculate the Soft CrossEntropy loss. The label can be float.
 
     Args:
@@ -107,9 +105,10 @@ def binary_cross_entropy(pred,
     Returns:
         torch.Tensor: The calculated loss
     """
-    assert pred.dim() == label.dim()
     # Ensure that the size of class_weight is consistent with pred and label to
     # avoid automatic boracast,
+    assert pred.dim() == label.dim()
+
     if class_weight is not None:
         N = pred.size()[0]
         class_weight = class_weight.repeat(N, 1)
@@ -146,7 +145,8 @@ class CrossEntropyLoss(nn.Module):
         class_weight (List[float], optional): The weight for each class with
             shape (C), C is the number of classes. Default None.
         pos_weight (List[float], optional): The positive weight for each
-            class with shape (C), C is the number of classes. Default None.
+            class with shape (C), C is the number of classes. Only enabled in
+            BCE loss when ``use_sigmoid`` is True. Default None.
     """
 
     def __init__(self,
@@ -194,6 +194,7 @@ class CrossEntropyLoss(nn.Module):
         # only BCE loss has pos_weight
         if self.pos_weight is not None and self.use_sigmoid:
             pos_weight = cls_score.new_tensor(self.pos_weight)
+            kwargs.update({'pos_weight': pos_weight})
         else:
             pos_weight = None
 
@@ -204,6 +205,5 @@ class CrossEntropyLoss(nn.Module):
             class_weight=class_weight,
             reduction=reduction,
             avg_factor=avg_factor,
-            pos_weight=pos_weight,
             **kwargs)
         return loss_cls

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -75,6 +75,7 @@ def test_cross_entropy_loss():
     label = torch.Tensor([[1, 0], [0, 1], [1, 0]])
     weight = torch.Tensor([0.6, 0.4, 0.5])
     class_weight = [0.1, 0.9]  # class 0: 0.1, class 1: 0.9
+    pos_weight = [0.1, 0.2]
 
     # test bce_loss without class weight
     loss_cfg = dict(
@@ -100,6 +101,16 @@ def test_cross_entropy_loss():
     # test bce_loss with weight
     assert torch.allclose(
         loss(cls_score, label, weight=weight), torch.tensor(74.333))
+
+    # test bce loss with pos_weight
+    loss_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        loss_weight=1.0,
+        pos_weight=pos_weight)
+    loss = build_loss(loss_cfg)
+    assert torch.allclose(loss(cls_score, label), torch.tensor(136.6667))
 
     # test soft_ce_loss
     cls_score = torch.Tensor([[-1000, 1000], [100, -100]])


### PR DESCRIPTION
## Motivation

Add pos_weight in BCE

## Modification

Add pos_weight in BCE

## BC-breaking (Optional)
no

## Use cases (Optional)

```
pos_weight = [0.1, 0.2]
loss_cfg = dict(
        type='CrossEntropyLoss',
        use_sigmoid=True,
        reduction='mean',
        loss_weight=1.0,
        pos_weight=pos_weight)
loss = build_loss(loss_cfg)
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
