### PR TITLE
[Fix] Fix an error on indexing scalar metrics in `analyze_result.py`

### DIFF
--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -97,6 +97,7 @@ def main():
     outputs['gt_label'] = gt_labels
     outputs['gt_class'] = gt_classes
 
+    outputs = {k: v for k, v in outputs.items() if isinstance(v, list)}
     outputs_list = list()
     for i in range(len(gt_labels)):
         output = dict()

--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -97,7 +97,11 @@ def main():
     outputs['gt_label'] = gt_labels
     outputs['gt_class'] = gt_classes
 
-    outputs = {k: v for k, v in outputs.items() if isinstance(v, list)}
+    need_keys = [
+        'filename', 'gt_label', 'gt_class', 'pred_score', 'pred_label',
+        'pred_class'
+    ]
+    outputs = {k: v for k, v in outputs.items() if k in need_keys}
     outputs_list = list()
     for i in range(len(gt_labels)):
         output = dict()


### PR DESCRIPTION
## Motivation

The output json file from the `test.py` script could contain scalar item, but the `analyze_result.py` presumes the item from the result json is a list. This PR filter the scalar item before indexing them.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [X] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [X] CLA has been signed and all committers have signed the CLA in this PR.
