### PR TITLE
[Fix] Fix a bug when load checkpoints in mulit-GPUs environment.

### DIFF
--- a/mmcls/apis/inference.py
+++ b/mmcls/apis/inference.py
@@ -34,7 +34,9 @@ def init_model(config, checkpoint=None, device='cuda:0', options=None):
     config.model.pretrained = None
     model = build_classifier(config.model)
     if checkpoint is not None:
-        checkpoint = load_checkpoint(model, checkpoint, map_location=device)
+        # Mapping the weights to GPU may cause unexpected video memory leak
+        # which refers to https://github.com/open-mmlab/mmdetection/pull/6405
+        checkpoint = load_checkpoint(model, checkpoint, map_location='cpu')
         if 'CLASSES' in checkpoint.get('meta', {}):
             model.CLASSES = checkpoint['meta']['CLASSES']
         else:

--- a/mmcls/apis/inference.py
+++ b/mmcls/apis/inference.py
@@ -34,8 +34,7 @@ def init_model(config, checkpoint=None, device='cuda:0', options=None):
     config.model.pretrained = None
     model = build_classifier(config.model)
     if checkpoint is not None:
-        map_loc = 'cpu' if device == 'cpu' else None
-        checkpoint = load_checkpoint(model, checkpoint, map_location=map_loc)
+        checkpoint = load_checkpoint(model, checkpoint, map_location=device)
         if 'CLASSES' in checkpoint.get('meta', {}):
             model.CLASSES = checkpoint['meta']['CLASSES']
         else:


### PR DESCRIPTION
## Motivation

Refers to https://github.com/open-mmlab/mmdetection/pull/6405

## Modification

When loading a checkpoint, map the checkpoint to the CPU, instead of `None` in a multi-GPUs environment.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
