### PR TITLE
[Refactor] Use `reset_classifier` to remove head of timm backbones.

### DIFF
--- a/mmcls/models/backbones/timm_backbone.py
+++ b/mmcls/models/backbones/timm_backbone.py
@@ -44,9 +44,7 @@ class TIMMBackbone(BaseBackbone):
         )
 
         # Make unused parameters None
-        self.timm_model.global_pool = None
-        self.timm_model.fc = None
-        self.timm_model.classifier = None
+        self.timm_model.reset_classifier(0, '')
 
         # Hack to use pretrained weights from timm
         if pretrained or checkpoint_path:

--- a/mmcls/models/backbones/timm_backbone.py
+++ b/mmcls/models/backbones/timm_backbone.py
@@ -43,7 +43,7 @@ class TIMMBackbone(BaseBackbone):
             **kwargs,
         )
 
-        # Make unused parameters None
+        # reset classifier
         self.timm_model.reset_classifier(0, '')
 
         # Hack to use pretrained weights from timm

--- a/tests/test_models/test_backbones/test_timm_backbone.py
+++ b/tests/test_models/test_backbones/test_timm_backbone.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from torch import nn
 from torch.nn.modules.batchnorm import _BatchNorm
 
 from mmcls.models.backbones import TIMMBackbone
@@ -26,6 +27,8 @@ def test_timm_backbone():
     model.init_weights()
     model.train()
     assert check_norm_state(model.modules(), True)
+    assert isinstance(model.timm_model.global_pool.pool, nn.Identity)
+    assert isinstance(model.timm_model.fc, nn.Identity)
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
@@ -36,8 +39,21 @@ def test_timm_backbone():
     model = TIMMBackbone(model_name='efficientnet_b1', pretrained=True)
     model.init_weights()
     model.train()
+    assert isinstance(model.timm_model.global_pool.pool, nn.Identity)
+    assert isinstance(model.timm_model.classifier, nn.Identity)
 
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
     assert len(feat) == 1
     assert feat[0].shape == torch.Size((1, 1280, 7, 7))
+
+    # Test vit_tiny_patch16_224 with pretrained weights
+    model = TIMMBackbone(model_name='vit_tiny_patch16_224', pretrained=True)
+    model.init_weights()
+    model.train()
+    assert isinstance(model.timm_model.head, nn.Identity)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size((1, 192))


### PR DESCRIPTION
## Motivation

Some of timm models have different name of classifier. For example vision transformer's classifier name is [head](https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py#L293). 
And timm has 'reset_classifier' to fix classifier. So it looks better to use it.

## Modification

Using `reset_classifier` to make unused parameters `nn.Identity`.
Add test to check `global_pool` and `classifier` is nn.Identity.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
No.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
