### PR TITLE
fix bug when using iterbaserunner with 'val' workflow

### DIFF
--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -129,9 +129,9 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
 
         Args:
             data (dict): The output of dataloader.
-            optimizer (:obj:`torch.optim.Optimizer` | dict): The optimizer of
-                runner is passed to ``train_step()``. This argument is unused
-                and reserved.
+            optimizer (:obj:`torch.optim.Optimizer` | dict | optional): The
+                optimizer of runner is passed to ``train_step()``. This argument
+                 is unused and reserved.
 
         Returns:
             dict: Dict of outputs. The following fields are contained.
@@ -157,6 +157,22 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
         This method shares the same signature as :func:`train_step`, but used
         during val epochs. Note that the evaluation after training epochs is
         not implemented with this method, but an evaluation hook.
+
+        Args:
+            data (dict): The output of dataloader.
+            optimizer (:obj:`torch.optim.Optimizer` | dict | optional): The
+                optimizer of runner is passed to ``train_step()``. This argument
+                 is unused and reserved.
+
+        Returns:
+            dict: Dict of outputs. The following fields are contained.
+                - loss (torch.Tensor): A tensor for back propagation, which \
+                    can be a weighted sum of multiple losses.
+                - log_vars (dict): Dict contains all the variables to be sent \
+                    to the logger.
+                - num_samples (int): Indicates the batch size (when the model \
+                    is DDP, it means the batch size on each GPU), which is \
+                    used for averaging the logs.
         """
         losses = self(**data)
         loss, log_vars = self._parse_losses(losses)

--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -130,8 +130,8 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
         Args:
             data (dict): The output of dataloader.
             optimizer (:obj:`torch.optim.Optimizer` | dict | optional): The
-                optimizer of runner is passed to ``train_step()``. This argument
-                 is unused and reserved.
+                optimizer of runner is passed to ``train_step()``. This
+                argument is unused and reserved.
 
         Returns:
             dict: Dict of outputs. The following fields are contained.
@@ -161,8 +161,8 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
         Args:
             data (dict): The output of dataloader.
             optimizer (:obj:`torch.optim.Optimizer` | dict | optional): The
-                optimizer of runner is passed to ``train_step()``. This argument
-                 is unused and reserved.
+                optimizer of runner is passed to ``train_step()``. This
+                argument is unused and reserved.
 
         Returns:
             dict: Dict of outputs. The following fields are contained.

--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -118,7 +118,7 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
 
         return loss, log_vars
 
-    def train_step(self, data, optimizer):
+    def train_step(self, data, optimizer=None, **kwargs):
         """The iteration step during training.
 
         This method defines an iteration step during training, except for the
@@ -151,7 +151,7 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
 
         return outputs
 
-    def val_step(self, data, optimizer):
+    def val_step(self, data, optimizer=None, **kwargs):
         """The iteration step during validation.
 
         This method shares the same signature as :func:`train_step`, but used

--- a/mmcls/models/classifiers/base.py
+++ b/mmcls/models/classifiers/base.py
@@ -129,7 +129,7 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
 
         Args:
             data (dict): The output of dataloader.
-            optimizer (:obj:`torch.optim.Optimizer` | dict | optional): The
+            optimizer (:obj:`torch.optim.Optimizer` | dict, optional): The
                 optimizer of runner is passed to ``train_step()``. This
                 argument is unused and reserved.
 
@@ -160,7 +160,7 @@ class BaseClassifier(BaseModule, metaclass=ABCMeta):
 
         Args:
             data (dict): The output of dataloader.
-            optimizer (:obj:`torch.optim.Optimizer` | dict | optional): The
+            optimizer (:obj:`torch.optim.Optimizer` | dict, optional): The
                 optimizer of runner is passed to ``train_step()``. This
                 argument is unused and reserved.
 

--- a/tests/test_models/test_classifiers.py
+++ b/tests/test_models/test_classifiers.py
@@ -44,8 +44,18 @@ def test_image_classifier():
     assert outputs['loss'].item() > 0
     assert outputs['num_samples'] == 16
 
+    # test train_step without optimizer
+    outputs = model.train_step({'img': imgs, 'gt_label': label})
+    assert outputs['loss'].item() > 0
+    assert outputs['num_samples'] == 16
+
     # test val_step
     outputs = model.val_step({'img': imgs, 'gt_label': label}, None)
+    assert outputs['loss'].item() > 0
+    assert outputs['num_samples'] == 16
+
+    # test val_step without optimizer
+    outputs = model.val_step({'img': imgs, 'gt_label': label})
     assert outputs['loss'].item() > 0
     assert outputs['num_samples'] == 16
 


### PR DESCRIPTION
## Motivation

fix bug when using iterbaserunner with 'val' workflow. refer to #535 
Align the train_step and val_step with [epochBaseRunner](https://github.com/open-mmlab/mmcv/blob/add157cc73b05c7be3d9b63505e17dc2288a6d0f/mmcv/runner/epoch_based_runner.py#L29)  and [iterBaseRunner](https://github.com/open-mmlab/mmcv/blob/master/mmcv/runner/iter_based_runner.py) in mmcv 


## Modification

add a default value None for optimizer
add kwargs


## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
