### PR TITLE
[Refactor] Remove useless `import_modules_from_string`.

### DIFF
--- a/tools/analysis_tools/eval_metric.py
+++ b/tools/analysis_tools/eval_metric.py
@@ -51,10 +51,6 @@ def main():
 
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     cfg.data.test.test_mode = True
 
     dataset = build_dataset(cfg.data.test)

--- a/tools/misc/print_config.py
+++ b/tools/misc/print_config.py
@@ -44,10 +44,6 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     print(f'Config:\n{cfg.pretty_text}')
 
 

--- a/tools/visualizations/vis_pipeline.py
+++ b/tools/visualizations/vis_pipeline.py
@@ -119,10 +119,6 @@ def retrieve_data_cfg(config_path, skip_type, cfg_options, phase):
     cfg = Config.fromfile(config_path)
     if cfg_options is not None:
         cfg.merge_from_dict(cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     data_cfg = cfg.data[phase]
     while 'dataset' in data_cfg:
         data_cfg = data_cfg['dataset']


### PR DESCRIPTION
## Motivation

Now mmcv can handle `custom_imports`, so we don't need `import_modules_from_string`.

## Modification

As the title.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
