### PR TITLE
[Fix] Fix interpolation method checking in `Resize`

### DIFF
--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -677,8 +677,10 @@ class Resize(object):
             (224, -1) and adaptive_size is "short", the short side is resized
             to 224 and the other side is computed based on the short side,
             maintaining the aspect ratio.
-        interpolation (str): Interpolation method, accepted values are
-            "nearest", "bilinear", "bicubic", "area", "lanczos".
+        interpolation (str): Interpolation method. For "cv2" backend, accepted
+            values are "nearest", "bilinear", "bicubic", "area", "lanczos". For
+            "pillow" backend, accepted values are "nearest", "bilinear",
+            "bicubic", "box", "lanczos", "hamming".
             More details can be found in `mmcv.image.geometric`.
         adaptive_side(str): Adaptive resize policy, accepted values are
             "short", "long", "height", "width". Default to "short".

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -704,12 +704,15 @@ class Resize(object):
             assert size[0] > 0 and (size[1] > 0 or size[1] == -1)
             if size[1] == -1:
                 self.adaptive_resize = True
-        assert interpolation in ('nearest', 'bilinear', 'bicubic', 'area',
-                                 'lanczos')
         if backend not in ['cv2', 'pillow']:
             raise ValueError(f'backend: {backend} is not supported for resize.'
                              'Supported backends are "cv2", "pillow"')
-
+        if backend == 'cv2':
+            assert interpolation in ('nearest', 'bilinear', 'bicubic', 'area',
+                                     'lanczos')
+        else:
+            assert interpolation in ('nearest', 'bilinear', 'bicubic', 'box',
+                                     'lanczos', 'hamming')
         self.size = size
         self.interpolation = interpolation
         self.backend = backend

--- a/tests/test_data/test_pipelines/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform.py
@@ -214,6 +214,20 @@ def test_resize():
     assert np.equal(results['img'], results['img2']).all()
     assert results['img_shape'] == (336, 224, 3)
 
+    # test interpolation method checking
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='Resize', size=(300, 200), backend='cv2', interpolation='box')
+        resize_module = build_from_cfg(transform, PIPELINES)
+
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='Resize',
+            size=(300, 200),
+            backend='pillow',
+            interpolation='area')
+        resize_module = build_from_cfg(transform, PIPELINES)
+
 
 def test_pad():
     results = dict()


### PR DESCRIPTION
## Motivation

`mmcv.imresize` with `pillow` backend support different interpolation methods with `cv2` ones. Interpolation method checking in `Resize` raise an error for some of the use case, e.g. `Resize(size=SIZE, interpolation='box', backend='pillow')`.

## Modification

Perform an interpolation method check for pillow backend and cv2 backend, respectively.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
