### PR TITLE
[Refactor] Use new API of matplotlib to handle blocking input in visualization.

### DIFF
--- a/tests/test_utils/test_visualization.py
+++ b/tests/test_utils/test_visualization.py
@@ -1,9 +1,8 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 import os
 import os.path as osp
-import shutil
 import tempfile
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock
 
 import matplotlib.pyplot as plt
 import mmcv
@@ -52,30 +51,8 @@ def test_imshow_infos():
     assert image.shape == out_image.shape[:2]
     os.remove(tmp_filename)
 
-    # test show=True
-    image = np.ones((10, 10, 3), np.uint8)
-    result = {'pred_label': 1, 'pred_class': 'bird', 'pred_score': 0.98}
 
-    def mock_blocking_input(self, n=1, timeout=30):
-        keypress = Mock()
-        keypress.key = ' '
-        out_path = osp.join(tmp_dir, '_'.join([str(n), str(timeout)]))
-        with open(out_path, 'w') as f:
-            f.write('test')
-        return [keypress]
-
-    with patch('matplotlib.blocking_input.BlockingInput.__call__',
-               mock_blocking_input):
-        vis.imshow_infos(image, result, show=True, wait_time=5)
-        assert osp.exists(osp.join(tmp_dir, '1_0'))
-
-    shutil.rmtree(tmp_dir)
-
-
-@patch(
-    'matplotlib.blocking_input.BlockingInput.__call__',
-    return_value=[Mock(key=' ')])
-def test_context_manager(mock_blocking_input):
+def test_figure_context_manager():
     # test show multiple images with the same figure.
     images = [
         np.random.randint(0, 255, (100, 100, 3), np.uint8) for _ in range(5)
@@ -85,6 +62,10 @@ def test_context_manager(mock_blocking_input):
     with vis.ImshowInfosContextManager() as manager:
         fig_show = manager.fig_show
         fig_save = manager.fig_save
+
+        # Test time out
+        fig_show.canvas.start_event_loop = MagicMock()
+        fig_show.canvas.end_event_loop = MagicMock()
         for image in images:
             ret, out_image = manager.put_img_infos(image, result, show=True)
             assert ret == 0
@@ -93,16 +74,27 @@ def test_context_manager(mock_blocking_input):
             assert fig_show is manager.fig_show
             assert fig_save is manager.fig_save
 
-    # test rebuild figure if user destroyed it.
-    with vis.ImshowInfosContextManager() as manager:
-        fig_save = manager.fig_save
+        # Test continue key
+        fig_show.canvas.start_event_loop = (
+            lambda _: fig_show.canvas.key_press_event(' '))
         for image in images:
-            fig_show = manager.fig_show
-            plt.close(manager.fig_show)
-
             ret, out_image = manager.put_img_infos(image, result, show=True)
             assert ret == 0
             assert image.shape == out_image.shape
             assert not np.allclose(image, out_image)
-            assert not (fig_show is manager.fig_show)
+            assert fig_show is manager.fig_show
             assert fig_save is manager.fig_save
+
+        # Test close figure manually
+        fig_show = manager.fig_show
+
+        def destroy(*_, **__):
+            fig_show.canvas.close_event()
+            plt.close(fig_show)
+
+        fig_show.canvas.start_event_loop = destroy
+        ret, out_image = manager.put_img_infos(images[0], result, show=True)
+        assert ret == 1
+        assert image.shape == out_image.shape
+        assert not np.allclose(image, out_image)
+        assert fig_save is manager.fig_save

--- a/tests/test_utils/test_visualization.py
+++ b/tests/test_utils/test_visualization.py
@@ -86,7 +86,8 @@ def test_context_manager(mock_blocking_input):
         fig_show = manager.fig_show
         fig_save = manager.fig_save
         for image in images:
-            out_image = manager.put_img_infos(image, result, show=True)
+            ret, out_image = manager.put_img_infos(image, result, show=True)
+            assert ret == 0
             assert image.shape == out_image.shape
             assert not np.allclose(image, out_image)
             assert fig_show is manager.fig_show
@@ -99,7 +100,8 @@ def test_context_manager(mock_blocking_input):
             fig_show = manager.fig_show
             plt.close(manager.fig_show)
 
-            out_image = manager.put_img_infos(image, result, show=True)
+            ret, out_image = manager.put_img_infos(image, result, show=True)
+            assert ret == 0
             assert image.shape == out_image.shape
             assert not np.allclose(image, out_image)
             assert not (fig_show is manager.fig_show)

--- a/tools/visualizations/vis_pipeline.py
+++ b/tools/visualizations/vis_pipeline.py
@@ -238,7 +238,7 @@ def main():
 
             infos = dict(label=CLASSES[item['gt_label']])
 
-            manager.put_img_infos(
+            ret, _ = manager.put_img_infos(
                 image,
                 infos,
                 font_size=20,
@@ -247,6 +247,10 @@ def main():
                 **args.show_options)
 
             progressBar.update()
+
+            if ret == 1:
+                print('\nMannualy interrupted.')
+                break
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

In matplotlib 3.5, the `matplotlib.blocking_input` module has been deprecated, which refers to this [link](https://github.com/anntzer/matplotlib/blob/b2a7521f69a8d9b08beffef9fc31fbf555e93abf/doc/api/next_api_changes/deprecations/20208-AL.rst).
Closing #566.

## Modification

- As the title.
- And add a return value to `BaseFigureContextManager.wait_continue()` to indicate whether the user presses the continue key or closes the figure.
- In `tools/visualizations/vis_pipeline.py`, the progress will be interrupted if the user closes the show figure.

## BC-breaking (Optional)

If users use the return value of `ImshowInfosContextManager.put_img_infos`, they need a small modification, from
```python
img = manager.put_img_infos(img, {'info': 'text'})
```
to
```python
_, img = manager.put_img_infos(img, {'info': 'text'})
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
