### PR TITLE
[Fix] Fix a bug for multiple output in swin transformer.

### DIFF
--- a/mmcls/models/backbones/swin_transformer.py
+++ b/mmcls/models/backbones/swin_transformer.py
@@ -346,7 +346,7 @@ class SwinTransformer(BaseBackbone):
 
         for i in out_indices:
             if norm_cfg is not None:
-                norm_layer = build_norm_layer(norm_cfg, embed_dims[i+1])[1]
+                norm_layer = build_norm_layer(norm_cfg, embed_dims[i + 1])[1]
             else:
                 norm_layer = nn.Identity()
 

--- a/mmcls/models/backbones/swin_transformer.py
+++ b/mmcls/models/backbones/swin_transformer.py
@@ -317,7 +317,7 @@ class SwinTransformer(BaseBackbone):
         ]  # stochastic depth decay rule
 
         self.stages = ModuleList()
-        embed_dims = self.embed_dims
+        embed_dims = [self.embed_dims]
         input_resolution = patches_resolution
         for i, (depth,
                 num_heads) in enumerate(zip(self.depths, self.num_heads)):
@@ -327,7 +327,7 @@ class SwinTransformer(BaseBackbone):
                 stage_cfg = deepcopy(stage_cfgs)
             downsample = True if i < self.num_layers - 1 else False
             _stage_cfg = {
-                'embed_dims': embed_dims,
+                'embed_dims': embed_dims[-1],
                 'depth': depth,
                 'num_heads': num_heads,
                 'downsample': downsample,
@@ -341,12 +341,12 @@ class SwinTransformer(BaseBackbone):
             self.stages.append(stage)
 
             dpr = dpr[depth:]
-            embed_dims = stage.out_channels
+            embed_dims.append(stage.out_channels)
             input_resolution = stage.out_resolution
 
         for i in out_indices:
             if norm_cfg is not None:
-                norm_layer = build_norm_layer(norm_cfg, embed_dims)[1]
+                norm_layer = build_norm_layer(norm_cfg, embed_dims[i+1])[1]
             else:
                 norm_layer = nn.Identity()
 

--- a/tests/test_models/test_backbones/test_swin_transformer.py
+++ b/tests/test_models/test_backbones/test_swin_transformer.py
@@ -77,6 +77,15 @@ def test_forward():
     assert len(output) == 1
     assert output[0].shape == (1, 1024, 12, 12)
 
+    # Test multiple output indices
+    imgs = torch.randn(1, 3, 224, 224)
+    model = SwinTransformer(arch='base', out_indices=(0, 1, 2, 3))
+    outs = model(imgs)
+    assert outs[0].shape == (1, 256, 28, 28)
+    assert outs[1].shape == (1, 512, 14, 14)
+    assert outs[2].shape == (1, 1024, 7, 7)
+    assert outs[3].shape == (1, 1024, 7, 7)
+
 
 def test_structure():
     # Test small with use_abs_pos_embed = True


### PR DESCRIPTION
## Motivation

fix bug;

layer_norm 0,1,2,3  will be the same and resulted in an error when out_indices dict exceed one element. for example out_indices = (0,1,2,3)

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
