### PR TITLE
[Enhance] Try to create a symbolic link on windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,8 +131,20 @@ def add_mim_extension():
 
             if mode == 'symlink':
                 src_relpath = osp.relpath(src_path, osp.dirname(tar_path))
-                os.symlink(src_relpath, tar_path)
-            elif mode == 'copy':
+                try:
+                    os.symlink(src_relpath, tar_path)
+                except OSError:
+                    # Creating a symbolic link on windows may raise an
+                    # `OSError: [WinError 1314]` due to privilege. If
+                    # the error happens, the src file will be copied
+                    mode = 'copy'
+                    warnings.warn(
+                        f'Failed to create a symbolic link for {src_relpath}, '
+                        f'and it will be copied to {tar_path}')
+                else:
+                    continue
+
+            if mode == 'copy':
                 if osp.isfile(src_path):
                     shutil.copyfile(src_path, tar_path)
                 elif osp.isdir(src_path):


### PR DESCRIPTION
Refers to https://github.com/open-mmlab/mmflow/pull/37
Related Issue: [open-mmlab/mmdetection#6480](https://github.com/open-mmlab/mmdetection/issues/6480)

Creating a symbolic link on windows may raise an OSError: [WinError 1314] due to privilege. If the error happens, the src file will be copied.