### PR TITLE
[Refactor] Change `load_json_logs` to `load_json_log`.

### DIFF
--- a/mmcls/utils/__init__.py
+++ b/mmcls/utils/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .collect_env import collect_env
-from .logger import get_root_logger, load_json_logs
+from .logger import get_root_logger, load_json_log
 
-__all__ = ['collect_env', 'get_root_logger', 'load_json_logs']
+__all__ = ['collect_env', 'get_root_logger', 'load_json_log']

--- a/mmcls/utils/logger.py
+++ b/mmcls/utils/logger.py
@@ -10,28 +10,37 @@ def get_root_logger(log_file=None, log_level=logging.INFO):
     return get_logger('mmcls', log_file, log_level)
 
 
-def load_json_logs(json_logs):
+def load_json_log(json_log):
     """load and convert json_logs to log_dicts.
 
     Args:
-        json_logs (str): paths of json_logs.
+        json_log (str): The path of the json log file.
 
     Returns:
-        list[dict(int:dict())]: key is epoch, value is a sub dict keys of
-            sub dict is different metrics, e.g. memory, bbox_mAP, value of
-            sub dict is a list of corresponding values of all iterations.
+        dict[int, dict[str, list]]:
+            Key is the epoch, value is a sub dict. The keys in each sub dict
+            are different metrics, e.g. memory, bbox_mAP, and the value is a
+            list of corresponding values in all iterations in this epoch.
+
+            .. code-block:: python
+
+                # An example output
+                {
+                    1: {'iter': [100, 200, 300], 'loss': [6.94, 6.73, 6.53]},
+                    2: {'iter': [100, 200, 300], 'loss': [6.33, 6.20, 6.07]},
+                    ...
+                }
     """
-    log_dicts = [dict() for _ in json_logs]
-    for json_log, log_dict in zip(json_logs, log_dicts):
-        with open(json_log, 'r') as log_file:
-            for line in log_file:
-                log = json.loads(line.strip())
-                # skip lines without `epoch` field
-                if 'epoch' not in log:
-                    continue
-                epoch = log.pop('epoch')
-                if epoch not in log_dict:
-                    log_dict[epoch] = defaultdict(list)
-                for k, v in log.items():
-                    log_dict[epoch][k].append(v)
-    return log_dicts
+    log_dict = dict()
+    with open(json_log, 'r') as log_file:
+        for line in log_file:
+            log = json.loads(line.strip())
+            # skip lines without `epoch` field
+            if 'epoch' not in log:
+                continue
+            epoch = log.pop('epoch')
+            if epoch not in log_dict:
+                log_dict[epoch] = defaultdict(list)
+            for k, v in log.items():
+                log_dict[epoch][k].append(v)
+    return log_dict

--- a/tests/test_utils/test_logger.py
+++ b/tests/test_utils/test_logger.py
@@ -5,7 +5,7 @@ import tempfile
 
 import mmcv.utils.logging
 
-from mmcls.utils import get_root_logger, load_json_logs
+from mmcls.utils import get_root_logger, load_json_log
 
 
 def test_get_root_logger():
@@ -31,16 +31,11 @@ def test_get_root_logger():
         os.remove(log_path)
 
 
-def test_load_json_logs():
+def test_load_json_log():
     log_path = 'tests/data/test.logjson'
-    log_dicts = load_json_logs([log_path])
-
-    # test log_dicts
-    assert isinstance(log_dicts, list)
-    assert len(log_dicts) == 1
+    log_dict = load_json_log(log_path)
 
     # test log_dict
-    log_dict = log_dicts[0]
     assert set(log_dict.keys()) == set([1, 2, 3])
 
     # test epoch dict in log_dict

--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -6,7 +6,7 @@ import re
 import matplotlib.pyplot as plt
 import numpy as np
 
-from mmcls.utils import load_json_logs
+from mmcls.utils import load_json_log
 
 TEST_METRICS = ('precision', 'recall', 'f1_score', 'support', 'mAP', 'CP',
                 'CR', 'CF1', 'OP', 'OR', 'OF1', 'accuracy')
@@ -206,7 +206,7 @@ def main():
     for json_log in json_logs:
         assert json_log.endswith('.json')
 
-    log_dicts = load_json_logs(json_logs)
+    log_dicts = [load_json_log(json_log) for json_log in json_logs]
 
     eval(args.task)(log_dicts, args)
 


### PR DESCRIPTION
## Motivation

The structure of `load_json_logs`'s output is too complex.

## Modification

Change it to `load_json_log` and fix docstring.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
