### PR TITLE
[Enhance] Support single-label, softmax, custom eps by asymmetric loss

### DIFF
--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -36,6 +36,46 @@ def test_asymmetric_loss():
     loss = build_loss(loss_cfg)
     assert torch.allclose(loss(cls_score, label), torch.tensor(5.1186 / 3))
 
+    # test asymmetric_loss with softmax for single label task
+    cls_score = torch.Tensor([[5, -5, 0], [5, -5, 0]])
+    label = torch.Tensor([0, 1])
+    weight = torch.tensor([0.5, 0.5])
+    loss_cfg = dict(
+        type='AsymmetricLoss',
+        gamma_pos=0.0,
+        gamma_neg=0.0,
+        clip=None,
+        reduction='mean',
+        loss_weight=1.0,
+        use_sigmoid=False,
+        eps=1e-8)
+    loss = build_loss(loss_cfg)
+    # test asymmetric_loss for single label task without weight
+    assert torch.allclose(loss(cls_score, label), torch.tensor(2.5045))
+    # test asymmetric_loss for single label task with weight
+    assert torch.allclose(
+        loss(cls_score, label, weight=weight), torch.tensor(2.5045 * 0.5))
+
+    # test soft asymmetric_loss with softmax
+    cls_score = torch.Tensor([[5, -5, 0], [5, -5, 0]])
+    label = torch.Tensor([[1, 0, 0], [0, 1, 0]])
+    weight = torch.tensor([0.5, 0.5])
+    loss_cfg = dict(
+        type='AsymmetricLoss',
+        gamma_pos=0.0,
+        gamma_neg=0.0,
+        clip=None,
+        reduction='mean',
+        loss_weight=1.0,
+        use_sigmoid=False,
+        eps=1e-8)
+    loss = build_loss(loss_cfg)
+    # test soft asymmetric_loss with softmax without weight
+    assert torch.allclose(loss(cls_score, label), torch.tensor(2.5045))
+    # test soft asymmetric_loss with softmax with weight
+    assert torch.allclose(
+        loss(cls_score, label, weight=weight), torch.tensor(2.5045 * 0.5))
+
 
 def test_cross_entropy_loss():
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Motivation

The current implementation of asymmetric loss is hard-coded to work for only multi-label task with sigmoid and fixed eps value. 
By this modification, users can use asymmetric loss for single-label task and/or specified eps value.

## Modification

Support single-label, softmax, custom eps by asymmetric loss.

## BC-breaking (Optional)

This modification keeps backward compatibility.

## Use cases (Optional)

- Use asymmetric loss for single-label tasks
- Use asymmetric loss with user-specified eps value for multi-label or single-label tasks

## Checklist

**Before PR**:

- [x ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x ] CLA has been signed and all committers have signed the CLA in this PR.
