### PR TITLE
[Refactor] Save class names in best checkpoint created by evaluation hook

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -154,18 +154,19 @@ def main():
     model.init_weights()
 
     datasets = [build_dataset(cfg.data.train)]
-    meta['CLASSES'] = datasets[0].CLASSES
     if len(cfg.workflow) == 2:
         val_dataset = copy.deepcopy(cfg.data.val)
         val_dataset.pipeline = cfg.data.train.pipeline
         datasets.append(build_dataset(val_dataset))
-    if cfg.checkpoint_config is not None:
-        # save mmcls version, config file content and class names in
-        # checkpoints as meta data
-        cfg.checkpoint_config.meta = dict(
+
+    # save mmcls version, config file content and class names in
+    # runner as meta data
+    meta.update(
+        dict(
             mmcls_version=__version__,
             config=cfg.pretty_text,
-            CLASSES=datasets[0].CLASSES)
+            CLASSES=datasets[0].CLASSES))
+
     # add an attribute for visualization convenience
     train_model(
         model,

--- a/tools/train.py
+++ b/tools/train.py
@@ -154,6 +154,7 @@ def main():
     model.init_weights()
 
     datasets = [build_dataset(cfg.data.train)]
+    meta['CLASSES'] = datasets[0].CLASSES
     if len(cfg.workflow) == 2:
         val_dataset = copy.deepcopy(cfg.data.val)
         val_dataset.pipeline = cfg.data.train.pipeline


### PR DESCRIPTION
## Motivation

Currently, `mmcls` only save class names of dataset in `checkpoint` hook by populate the `meta` dictionary in here:
https://github.com/open-mmlab/mmclassification/blob/5232965b17b6c050f9b328b3740c631ed4034624/tools/train.py#L164

At the meantime, the `evaluation` hook use the `meta` dictionary form the runner which doesn't contains the classes name information, so the best checkpoint created by the `evaluation` hook won't contains `CLASSES` key. This is not very user friendly for training model on custom dataset because the test will load the `ImageNet` categories if the `CLASSES` key is missed in the `meta` dictionary of the checkpoint.

https://github.com/open-mmlab/mmclassification/blob/5232965b17b6c050f9b328b3740c631ed4034624/tools/test.py#L156

## Modification

Populate the class names of training dataset into the `meta` dictionary of runner.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
