### PR TITLE
[Feature] Support features_only in TIMMBackbone

### DIFF
--- a/mmcls/models/backbones/timm_backbone.py
+++ b/mmcls/models/backbones/timm_backbone.py
@@ -4,52 +4,109 @@ try:
 except ImportError:
     timm = None
 
+import warnings
+
+from mmcv.cnn.bricks.registry import NORM_LAYERS
+
+from ...utils import get_root_logger
 from ..builder import BACKBONES
 from .base_backbone import BaseBackbone
 
 
+def print_timm_feature_info(feature_info):
+    """Print feature_info of timm backbone to help development and debug.
+
+    Args:
+        feature_info (list[dict] | timm.models.features.FeatureInfo | None):
+            feature_info of timm backbone.
+    """
+    logger = get_root_logger()
+    if feature_info is None:
+        logger.warning('This backbone does not have feature_info')
+    elif isinstance(feature_info, list):
+        for feat_idx, each_info in enumerate(feature_info):
+            logger.info(f'backbone feature_info[{feat_idx}]: {each_info}')
+    else:
+        try:
+            logger.info(f'backbone out_indices: {feature_info.out_indices}')
+            logger.info(f'backbone out_channels: {feature_info.channels()}')
+            logger.info(f'backbone out_strides: {feature_info.reduction()}')
+        except AttributeError:
+            logger.warning('Unexpected format of backbone feature_info')
+
+
 @BACKBONES.register_module()
 class TIMMBackbone(BaseBackbone):
-    """Wrapper to use backbones from timm library. More details can be found in
-    `timm <https://github.com/rwightman/pytorch-image-models>`_ .
+    """Wrapper to use backbones from timm library.
+
+    More details can be found in
+    `timm <https://github.com/rwightman/pytorch-image-models>`_.
+    See especially the document for `feature extraction
+    <https://rwightman.github.io/pytorch-image-models/feature_extraction/>`_.
 
     Args:
         model_name (str): Name of timm model to instantiate.
-        pretrained (bool): Load pretrained weights if True.
-        checkpoint_path (str): Path of checkpoint to load after
-            model is initialized.
-        in_channels (int): Number of input image channels. Default: 3.
-        init_cfg (dict, optional): Initialization config dict
+        features_only (bool, optional): Whether to extract feature pyramid
+            (multi-scale feature maps from the deepest layer at each stride).
+            For Vision Transformer models that do not support this argument,
+            set this False. Default: False.
+        pretrained (bool, optional): Whether to load pretrained weights.
+            Default: False.
+        checkpoint_path (str, optional): Path of checkpoint to load at the
+            last of timm.create_model. Default: '', which means not loading.
+        in_channels (int, optional): Number of input image channels.
+            Default: 3.
+        init_cfg (dict or list[dict], optional): Initialization config dict of
+            OpenMMLab projects. Default: None.
         **kwargs: Other timm & model specific arguments.
     """
 
-    def __init__(
-        self,
-        model_name,
-        pretrained=False,
-        checkpoint_path='',
-        in_channels=3,
-        init_cfg=None,
-        **kwargs,
-    ):
+    def __init__(self,
+                 model_name,
+                 features_only=False,
+                 pretrained=False,
+                 checkpoint_path='',
+                 in_channels=3,
+                 init_cfg=None,
+                 **kwargs):
         if timm is None:
-            raise RuntimeError('timm is not installed')
+            raise RuntimeError(
+                'Failed to import timm. Please run "pip install timm". '
+                '"pip install dataclasses" may also be needed for Python 3.6.')
+        if not isinstance(pretrained, bool):
+            raise TypeError('pretrained must be bool, not str for model path')
+        if features_only and checkpoint_path:
+            warnings.warn(
+                'Using both features_only and checkpoint_path will cause error'
+                ' in timm. See '
+                'https://github.com/rwightman/pytorch-image-models/issues/488')
+
         super(TIMMBackbone, self).__init__(init_cfg)
+        if 'norm_layer' in kwargs:
+            kwargs['norm_layer'] = NORM_LAYERS.get(kwargs['norm_layer'])
         self.timm_model = timm.create_model(
             model_name=model_name,
+            features_only=features_only,
             pretrained=pretrained,
             in_chans=in_channels,
             checkpoint_path=checkpoint_path,
-            **kwargs,
-        )
+            **kwargs)
 
         # reset classifier
-        self.timm_model.reset_classifier(0, '')
+        if hasattr(self.timm_model, 'reset_classifier'):
+            self.timm_model.reset_classifier(0, '')
 
         # Hack to use pretrained weights from timm
         if pretrained or checkpoint_path:
             self._is_init = True
 
+        feature_info = getattr(self.timm_model, 'feature_info', None)
+        print_timm_feature_info(feature_info)
+
     def forward(self, x):
-        features = self.timm_model.forward_features(x)
-        return (features, )
+        features = self.timm_model(x)
+        if isinstance(features, (list, tuple)):
+            features = tuple(features)
+        else:
+            features = (features, )
+        return features

--- a/mmcls/models/backbones/timm_backbone.py
+++ b/mmcls/models/backbones/timm_backbone.py
@@ -46,18 +46,18 @@ class TIMMBackbone(BaseBackbone):
 
     Args:
         model_name (str): Name of timm model to instantiate.
-        features_only (bool, optional): Whether to extract feature pyramid
-            (multi-scale feature maps from the deepest layer at each stride).
-            For Vision Transformer models that do not support this argument,
-            set this False. Default: False.
-        pretrained (bool, optional): Whether to load pretrained weights.
-            Default: False.
-        checkpoint_path (str, optional): Path of checkpoint to load at the
-            last of timm.create_model. Default: '', which means not loading.
-        in_channels (int, optional): Number of input image channels.
-            Default: 3.
+        features_only (bool): Whether to extract feature pyramid (multi-scale
+            feature maps from the deepest layer at each stride). For Vision
+            Transformer models that do not support this argument,
+            set this False. Defaults to False.
+        pretrained (bool): Whether to load pretrained weights.
+            Defaults to False.
+        checkpoint_path (str): Path of checkpoint to load at the last of
+            ``timm.create_model``. Defaults to empty string, which means
+            not loading.
+        in_channels (int): Number of input image channels. Defaults to 3.
         init_cfg (dict or list[dict], optional): Initialization config dict of
-            OpenMMLab projects. Default: None.
+            OpenMMLab projects. Defaults to None.
         **kwargs: Other timm & model specific arguments.
     """
 

--- a/tests/data/retinanet.py
+++ b/tests/data/retinanet.py
@@ -1,5 +1,5 @@
 # small RetinaNet
-num_classes=3
+num_classes = 3
 
 # model settings
 model = dict(

--- a/tests/test_downstream/test_mmdet_inference.py
+++ b/tests/test_downstream/test_mmdet_inference.py
@@ -7,6 +7,7 @@ from mmdet.models import build_detector
 from mmcls.models import (MobileNetV2, MobileNetV3, RegNet, ResNeSt, ResNet,
                           ResNeXt, SEResNet, SEResNeXt, SwinTransformer,
                           TIMMBackbone)
+from mmcls.models.backbones.timm_backbone import timm
 
 backbone_configs = dict(
     mobilenetv2=dict(
@@ -92,7 +93,11 @@ def test_mmdet_inference():
     img1 = rng.rand(100, 100, 3)
 
     for module_name, backbone_config in backbone_configs.items():
-        print(module_name)
+        module = module_mapping[module_name]
+        if module is TIMMBackbone and timm is None:
+            print(f'skip {module_name} because timm is not available')
+            continue
+        print(f'test {module_name}')
         config = Config.fromfile(config_path)
         config.model.backbone = backbone_config['backbone']
         out_channels = backbone_config['out_channels']
@@ -105,7 +110,6 @@ def test_mmdet_inference():
             config.model.neck.in_channels = out_channels
 
         model = build_detector(config.model)
-        module = module_mapping[module_name]
         assert isinstance(model.backbone, module)
 
         model.cfg = config

--- a/tests/test_downstream/test_mmdet_inference.py
+++ b/tests/test_downstream/test_mmdet_inference.py
@@ -5,7 +5,8 @@ from mmdet.apis import inference_detector
 from mmdet.models import build_detector
 
 from mmcls.models import (MobileNetV2, MobileNetV3, RegNet, ResNeSt, ResNet,
-                          ResNeXt, SEResNet, SEResNeXt, SwinTransformer)
+                          ResNeXt, SEResNet, SEResNeXt, SwinTransformer,
+                          TIMMBackbone)
 
 backbone_configs = dict(
     mobilenetv2=dict(
@@ -52,7 +53,23 @@ backbone_configs = dict(
             img_size=800,
             out_indices=(2, 3),
             auto_pad=True),
-        out_channels=[384, 768]))
+        out_channels=[384, 768]),
+    timm_efficientnet=dict(
+        backbone=dict(
+            type='mmcls.TIMMBackbone',
+            model_name='efficientnet_b1',
+            features_only=True,
+            pretrained=False,
+            out_indices=(1, 2, 3, 4)),
+        out_channels=[24, 40, 112, 320]),
+    timm_resnet=dict(
+        backbone=dict(
+            type='mmcls.TIMMBackbone',
+            model_name='resnet50',
+            features_only=True,
+            pretrained=False,
+            out_indices=(1, 2, 3, 4)),
+        out_channels=[256, 512, 1024, 2048]))
 
 module_mapping = {
     'mobilenetv2': MobileNetV2,
@@ -63,7 +80,9 @@ module_mapping = {
     'seresnext': SEResNeXt,
     'seresnet': SEResNet,
     'resnest': ResNeSt,
-    'swin': SwinTransformer
+    'swin': SwinTransformer,
+    'timm_efficientnet': TIMMBackbone,
+    'timm_resnet': TIMMBackbone
 }
 
 
@@ -73,6 +92,7 @@ def test_mmdet_inference():
     img1 = rng.rand(100, 100, 3)
 
     for module_name, backbone_config in backbone_configs.items():
+        print(module_name)
         config = Config.fromfile(config_path)
         config.model.backbone = backbone_config['backbone']
         out_channels = backbone_config['out_channels']
@@ -91,6 +111,5 @@ def test_mmdet_inference():
         model.cfg = config
 
         model.eval()
-        print(module_name)
         result = inference_detector(model, img1)
         assert len(result) == config.num_classes

--- a/tests/test_models/test_backbones/test_timm_backbone.py
+++ b/tests/test_models/test_backbones/test_timm_backbone.py
@@ -17,10 +17,14 @@ def check_norm_state(modules, train_state):
 
 
 def test_timm_backbone():
+    """Test timm backbones, features_only=False (default)."""
     with pytest.raises(TypeError):
-        # pretrained must be a string path
-        model = TIMMBackbone()
-        model.init_weights(pretrained=0)
+        # TIMMBackbone has 1 required positional argument: 'model_name'
+        model = TIMMBackbone(pretrained=True)
+
+    with pytest.raises(TypeError):
+        # pretrained must be bool
+        model = TIMMBackbone(model_name='resnet18', pretrained='model.pth')
 
     # Test resnet18 from timm
     model = TIMMBackbone(model_name='resnet18')
@@ -57,3 +61,143 @@ def test_timm_backbone():
     feat = model(imgs)
     assert len(feat) == 1
     assert feat[0].shape == torch.Size((1, 192))
+
+
+def test_timm_backbone_features_only():
+    """Test timm backbones, features_only=True."""
+    # Test different norm_layer, can be: 'SyncBN', 'BN2d', 'GN', 'LN', 'IN'
+    # Test resnet18 from timm, norm_layer='BN2d'
+    model = TIMMBackbone(
+        model_name='resnet18',
+        features_only=True,
+        pretrained=False,
+        output_stride=32,
+        norm_layer='BN2d')
+
+    # Test resnet18 from timm, norm_layer='SyncBN'
+    model = TIMMBackbone(
+        model_name='resnet18',
+        features_only=True,
+        pretrained=False,
+        output_stride=32,
+        norm_layer='SyncBN')
+
+    # Test resnet18 from timm, output_stride=32
+    model = TIMMBackbone(
+        model_name='resnet18',
+        features_only=True,
+        pretrained=False,
+        output_stride=32)
+    model.init_weights()
+    model.train()
+    assert check_norm_state(model.modules(), True)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feats = model(imgs)
+    assert len(feats) == 5
+    assert feats[0].shape == torch.Size((1, 64, 112, 112))
+    assert feats[1].shape == torch.Size((1, 64, 56, 56))
+    assert feats[2].shape == torch.Size((1, 128, 28, 28))
+    assert feats[3].shape == torch.Size((1, 256, 14, 14))
+    assert feats[4].shape == torch.Size((1, 512, 7, 7))
+
+    # Test resnet18 from timm, output_stride=32, out_indices=(1, 2, 3)
+    model = TIMMBackbone(
+        model_name='resnet18',
+        features_only=True,
+        pretrained=False,
+        output_stride=32,
+        out_indices=(1, 2, 3))
+    imgs = torch.randn(1, 3, 224, 224)
+    feats = model(imgs)
+    assert len(feats) == 3
+    assert feats[0].shape == torch.Size((1, 64, 56, 56))
+    assert feats[1].shape == torch.Size((1, 128, 28, 28))
+    assert feats[2].shape == torch.Size((1, 256, 14, 14))
+
+    # Test resnet18 from timm, output_stride=16
+    model = TIMMBackbone(
+        model_name='resnet18',
+        features_only=True,
+        pretrained=False,
+        output_stride=16)
+    imgs = torch.randn(1, 3, 224, 224)
+    feats = model(imgs)
+    assert len(feats) == 5
+    assert feats[0].shape == torch.Size((1, 64, 112, 112))
+    assert feats[1].shape == torch.Size((1, 64, 56, 56))
+    assert feats[2].shape == torch.Size((1, 128, 28, 28))
+    assert feats[3].shape == torch.Size((1, 256, 14, 14))
+    assert feats[4].shape == torch.Size((1, 512, 14, 14))
+
+    # Test resnet18 from timm, output_stride=8
+    model = TIMMBackbone(
+        model_name='resnet18',
+        features_only=True,
+        pretrained=False,
+        output_stride=8)
+    imgs = torch.randn(1, 3, 224, 224)
+    feats = model(imgs)
+    assert len(feats) == 5
+    assert feats[0].shape == torch.Size((1, 64, 112, 112))
+    assert feats[1].shape == torch.Size((1, 64, 56, 56))
+    assert feats[2].shape == torch.Size((1, 128, 28, 28))
+    assert feats[3].shape == torch.Size((1, 256, 28, 28))
+    assert feats[4].shape == torch.Size((1, 512, 28, 28))
+
+    # Test efficientnet_b1 with pretrained weights
+    model = TIMMBackbone(
+        model_name='efficientnet_b1', features_only=True, pretrained=True)
+    imgs = torch.randn(1, 3, 64, 64)
+    feats = model(imgs)
+    assert len(feats) == 5
+    assert feats[0].shape == torch.Size((1, 16, 32, 32))
+    assert feats[1].shape == torch.Size((1, 24, 16, 16))
+    assert feats[2].shape == torch.Size((1, 40, 8, 8))
+    assert feats[3].shape == torch.Size((1, 112, 4, 4))
+    assert feats[4].shape == torch.Size((1, 320, 2, 2))
+
+    # Test resnetv2_50x1_bitm from timm, output_stride=8
+    model = TIMMBackbone(
+        model_name='resnetv2_50x1_bitm',
+        features_only=True,
+        pretrained=False,
+        output_stride=8)
+    imgs = torch.randn(1, 3, 8, 8)
+    feats = model(imgs)
+    assert len(feats) == 5
+    assert feats[0].shape == torch.Size((1, 64, 4, 4))
+    assert feats[1].shape == torch.Size((1, 256, 2, 2))
+    assert feats[2].shape == torch.Size((1, 512, 1, 1))
+    assert feats[3].shape == torch.Size((1, 1024, 1, 1))
+    assert feats[4].shape == torch.Size((1, 2048, 1, 1))
+
+    # Test resnetv2_50x3_bitm from timm, output_stride=8
+    model = TIMMBackbone(
+        model_name='resnetv2_50x3_bitm',
+        features_only=True,
+        pretrained=False,
+        output_stride=8)
+    imgs = torch.randn(1, 3, 8, 8)
+    feats = model(imgs)
+    assert len(feats) == 5
+    assert feats[0].shape == torch.Size((1, 192, 4, 4))
+    assert feats[1].shape == torch.Size((1, 768, 2, 2))
+    assert feats[2].shape == torch.Size((1, 1536, 1, 1))
+    assert feats[3].shape == torch.Size((1, 3072, 1, 1))
+    assert feats[4].shape == torch.Size((1, 6144, 1, 1))
+
+    # Test resnetv2_101x1_bitm from timm, output_stride=8
+    model = TIMMBackbone(
+        model_name='resnetv2_101x1_bitm',
+        features_only=True,
+        pretrained=False,
+        output_stride=8)
+    imgs = torch.randn(1, 3, 8, 8)
+    feats = model(imgs)
+    assert len(feats) == 5
+    assert feats[0].shape == torch.Size((1, 64, 4, 4))
+    assert feats[1].shape == torch.Size((1, 256, 2, 2))
+    assert feats[2].shape == torch.Size((1, 512, 1, 1))
+    assert feats[3].shape == torch.Size((1, 1024, 1, 1))
+    assert feats[4].shape == torch.Size((1, 2048, 1, 1))


### PR DESCRIPTION
## Motivation

See the discussion in https://github.com/open-mmlab/mmdetection/pull/7020. In MMDet, MMSeg, and other downstream repos, we wish to directly use backbones supported by TIMM in MMCls. Therefore, it is necessary to support this option for downstream tasks.
This PR will close https://github.com/open-mmlab/mmclassification/issues/665.
This PR (especially `test_timm_backbone_features_only`) is based on https://github.com/open-mmlab/mmsegmentation/pull/998.

## Modification

- [x] update TIMMBackbone to enable extracting feature pyramid (multi-scale feature maps) with `features_only=True`
- [x] update and enhance docstring and log messages
- [x] add unit tests for `features_only=True`
- [x] fix a minor bug in `test_timm_backbone`

## Use cases (Optional)

### MMDetection
Here is an example config `retinanet_timm_tv_resnet50_fpn_fp16_4x4_1x_coco.py`.
The results at epoch 1 (`bbox_mAP_copypaste: 0.162 0.285 0.164 0.084 0.201 0.201`) are similar to those of `retinanet_r50_fpn_fp16_1x_coco.py` ([`bbox_mAP_copypaste: 0.164 0.284 0.168 0.082 0.189 0.203`](https://download.openmmlab.com/mmdetection/v2.0/fp16/retinanet_r50_fpn_fp16_1x_coco/retinanet_r50_fpn_fp16_1x_coco_20200702_020127.log.json)).

```python
_base_ = [
    '../_base_/models/retinanet_r50_fpn.py',
    '../_base_/datasets/coco_detection.py',
    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
]

# import to trigger register_module in mmcls
custom_imports = dict(imports=['mmcls.models'], allow_failed_imports=False)
model = dict(
    backbone=dict(
        _delete_=True,
        type='mmcls.TIMMBackbone',
        model_name='tv_resnet50',  # ResNet-50 with torchvision weights
        features_only=True,
        pretrained=True,
        out_indices=(1, 2, 3, 4)))

optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)

# disable NumClassCheckHook
custom_hooks = []

data = dict(samples_per_gpu=4)

fp16 = dict(loss_scale=dict(init_scale=512))
```

### MMSegmentation
Here is an example config `upernet_timm_resnet50d_512x512_20k_voc12aug.py`.
mIoU 69.75 at 2000 iter. umm... too high? I'm not familiar with mmseg, and the config may be wrong.
In any case, training and evaluation work.

```python
_base_ = [
    '../_base_/models/upernet_r50.py',
    '../_base_/datasets/pascal_voc12_aug.py', '../_base_/default_runtime.py',
    '../_base_/schedules/schedule_20k.py'
]

# import to trigger register_module in mmcls
custom_imports = dict(imports=['mmcls.models'], allow_failed_imports=False)
model = dict(
    pretrained=None,
    backbone=dict(
        _delete_=True,
        type='mmcls.TIMMBackbone',
        model_name='resnet50d',  # instead of ResNet-50-C
        features_only=True,
        pretrained=True,
        out_indices=(1, 2, 3, 4),
        norm_layer='SyncBN'),
    decode_head=dict(num_classes=21),
    auxiliary_head=dict(num_classes=21))
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
