### PR TITLE
[Fix] Fix Conformer forward with irregular input size.

### DIFF
--- a/mmcls/models/backbones/conformer.py
+++ b/mmcls/models/backbones/conformer.py
@@ -439,13 +439,16 @@ class Conformer(BaseBackbone):
         self.maxpool = nn.MaxPool2d(
             kernel_size=3, stride=2, padding=1)  # 1 / 4 [56, 56]
 
+        assert patch_size % 16 == 0, 'The patch size of Conformer must ' \
+            'be divisible by 16.'
+        trans_down_stride = patch_size // 4
+
         # To solve the issue #680
-        # Auto pad the feature map to be divisible by 4
-        self.auto_pad = AdaptivePadding(kernel_size=4, stride=4)
+        # Auto pad the feature map to be divisible by trans_down_stride
+        self.auto_pad = AdaptivePadding(trans_down_stride, trans_down_stride)
 
         # 1 stage
         stage1_channels = int(base_channels * self.channel_ratio)
-        trans_down_stride = patch_size // 4
         self.conv_1 = ConvBlock(
             in_channels=64,
             out_channels=stage1_channels,

--- a/tests/test_models/test_backbones/test_conformer.py
+++ b/tests/test_models/test_backbones/test_conformer.py
@@ -57,6 +57,25 @@ def test_conformer_backbone():
                                   )  # base_channels * channel_ratio * 4
     assert transformer_feature.shape == (3, 384)
 
+    # Test Conformer with irregular input size.
+    model = Conformer(**cfg_ori)
+    model.init_weights()
+    model.train()
+
+    assert check_norm_state(model.modules(), True)
+
+    imgs = torch.randn(3, 3, 241, 241)
+    conv_feature, transformer_feature = model(imgs)[-1]
+    assert conv_feature.shape == (3, 64 * 1 * 4
+                                  )  # base_channels * channel_ratio * 4
+    assert transformer_feature.shape == (3, 384)
+
+    imgs = torch.randn(3, 3, 321, 221)
+    conv_feature, transformer_feature = model(imgs)[-1]
+    assert conv_feature.shape == (3, 64 * 1 * 4
+                                  )  # base_channels * channel_ratio * 4
+    assert transformer_feature.shape == (3, 384)
+
     # Test custom arch Conformer without output cls token
     cfg = deepcopy(cfg_ori)
     cfg['arch'] = {
@@ -72,7 +91,7 @@ def test_conformer_backbone():
     assert conv_feature.shape == (3, 32 * 3 * 4)
     assert transformer_feature.shape == (3, 128)
 
-    # Test ViT with multi out indices
+    # Test Conformer with multi out indices
     cfg = deepcopy(cfg_ori)
     cfg['out_indices'] = [4, 8, 12]
     model = Conformer(**cfg)


### PR DESCRIPTION
## Motivation

Fix #680 

## Modification

Use `AdaptivePadding` to pad the stem feature map to be divisible by 4.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
