### PR TITLE
Add deprecation message for deploy tools

### DIFF
--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -142,7 +142,12 @@ if __name__ == '__main__':
         workspace_size=args.workspace_size)
 
     import warnings
-    from colorama import Fore, Back, Style
+    try:
+        from colorama import Fore, Style, Back
+    except ImportError:
+        Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
+        Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
+        Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
 
     msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
     msg += 'DeprecationWarning: This tool will be deprecated in future. '

--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -2,7 +2,9 @@
 import argparse
 import os
 import os.path as osp
+import warnings
 
+import mmcv
 import numpy as np
 
 
@@ -141,13 +143,9 @@ if __name__ == '__main__':
         verify=args.verify,
         workspace_size=args.workspace_size)
 
-    import warnings
-    try:
-        from colorama import Fore, Style, Back
-    except ImportError:
-        Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
-        Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
-        Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
+    Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
+    Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
+    Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
 
     msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
     msg += 'DeprecationWarning: This tool will be deprecated in future. '

--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -140,3 +140,13 @@ if __name__ == '__main__':
         fp16_mode=args.fp16,
         verify=args.verify,
         workspace_size=args.workspace_size)
+
+    import warnings
+    from colorama import Fore, Back, Style
+
+    msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
+    msg += 'DeprecationWarning: This tool will be deprecated in future.'
+    msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += Style.RESET_ALL
+    warnings.warn(msg)

--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     from colorama import Fore, Back, Style
 
     msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
-    msg += 'DeprecationWarning: This tool will be deprecated in future.'
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
     msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
     msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
     msg += Style.RESET_ALL

--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -4,7 +4,6 @@ import os
 import os.path as osp
 import warnings
 
-import mmcv
 import numpy as np
 
 
@@ -143,13 +142,14 @@ if __name__ == '__main__':
         verify=args.verify,
         workspace_size=args.workspace_size)
 
-    Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
-    Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
-    Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
 
-    msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
+    msg = white_background + bright_style + red_text
     msg += 'DeprecationWarning: This tool will be deprecated in future. '
-    msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
     msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
-    msg += Style.RESET_ALL
+    msg += reset_style
     warnings.warn(msg)

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -236,7 +236,7 @@ if __name__ == '__main__':
     from colorama import Fore, Back, Style
 
     msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
-    msg += 'DeprecationWarning: This tool will be deprecated in future.'
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
     msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
     msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
     msg += Style.RESET_ALL

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
+import warnings
 from functools import partial
 
 import mmcv
@@ -232,8 +233,9 @@ if __name__ == '__main__':
         do_simplify=args.simplify,
         verify=args.verify)
 
-    import warnings
-    from colorama import Fore, Back, Style
+    Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
+    Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
+    Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
 
     msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
     msg += 'DeprecationWarning: This tool will be deprecated in future. '

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -233,13 +233,14 @@ if __name__ == '__main__':
         do_simplify=args.simplify,
         verify=args.verify)
 
-    Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
-    Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
-    Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
 
-    msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
+    msg = white_background + bright_style + red_text
     msg += 'DeprecationWarning: This tool will be deprecated in future. '
-    msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
     msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
-    msg += Style.RESET_ALL
+    msg += reset_style
     warnings.warn(msg)

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -231,3 +231,13 @@ if __name__ == '__main__':
         output_file=args.output_file,
         do_simplify=args.simplify,
         verify=args.verify)
+
+    import warnings
+    from colorama import Fore, Back, Style
+
+    msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
+    msg += 'DeprecationWarning: This tool will be deprecated in future.'
+    msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += Style.RESET_ALL
+    warnings.warn(msg)

--- a/tools/deployment/test.py
+++ b/tools/deployment/test.py
@@ -114,7 +114,10 @@ def main():
 
 if __name__ == '__main__':
     main()
-    from colorama import Fore, Back, Style
+
+    Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
+    Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
+    Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
 
     msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
     msg += 'DeprecationWarning: This tool will be deprecated in future. '

--- a/tools/deployment/test.py
+++ b/tools/deployment/test.py
@@ -114,3 +114,11 @@ def main():
 
 if __name__ == '__main__':
     main()
+    from colorama import Fore, Back, Style
+
+    msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
+    msg += 'DeprecationWarning: This tool will be deprecated in future.'
+    msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += Style.RESET_ALL
+    warnings.warn(msg)

--- a/tools/deployment/test.py
+++ b/tools/deployment/test.py
@@ -117,7 +117,7 @@ if __name__ == '__main__':
     from colorama import Fore, Back, Style
 
     msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
-    msg += 'DeprecationWarning: This tool will be deprecated in future.'
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
     msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
     msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
     msg += Style.RESET_ALL

--- a/tools/deployment/test.py
+++ b/tools/deployment/test.py
@@ -115,13 +115,14 @@ def main():
 if __name__ == '__main__':
     main()
 
-    Style = mmcv.ConfigDict({'BRIGHT': '\x1b[1m', 'RESET_ALL': '\x1b[0m'})
-    Fore = mmcv.ConfigDict({'RED': '\x1b[31m', 'BLUE': '\x1b[34m'})
-    Back = mmcv.ConfigDict({'LIGHTWHITE_EX': '\x1b[107m'})
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
 
-    msg = Back.LIGHTWHITE_EX + Style.BRIGHT + Fore.RED
+    msg = white_background + bright_style + red_text
     msg += 'DeprecationWarning: This tool will be deprecated in future. '
-    msg += Fore.BLUE + 'Welcome to use the unified model deployment toolbox '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
     msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
-    msg += Style.RESET_ALL
+    msg += reset_style
     warnings.warn(msg)


### PR DESCRIPTION
## Motivation

Since [MMDeploy](https://github.com/open-mmlab/mmdeploy) has been released, the deployment tools scattered in each OpenMMLab codebase will be deprecated in future.

## Modification

Add deprecation message in deployment tools.
Used package [colorama](https://github.com/tartley/colorama#colored-output) to print cross-platform colored text.


## BC-breaking (Optional)

None

## Use cases (Optional)

And the message would look like it in Ubuntu18.04 terminal:
![image](https://user-images.githubusercontent.com/28671653/154436568-9b36c248-812a-402f-bef8-5631ed8abd7a.png)
