### PR TITLE
[Enhance] Add get_cat_ids and get_gt_labels to KFoldDataset

### DIFF
--- a/mmcls/datasets/dataset_wrappers.py
+++ b/mmcls/datasets/dataset_wrappers.py
@@ -311,6 +311,14 @@ class KFoldDataset:
         else:
             self.indices = indices[:test_start] + indices[test_end:]
 
+    def get_cat_ids(self, idx):
+        return self.dataset.get_cat_ids(self.indices[idx])
+
+    def get_gt_labels(self):
+        dataset_gt_labels = self.dataset.get_gt_labels()
+        gt_labels = np.array([dataset_gt_labels[idx] for idx in self.indices])
+        return gt_labels
+
     def __getitem__(self, idx):
         return self.dataset[self.indices[idx]]
 


### PR DESCRIPTION
## Motivation

KFoldDataset isn't implemented get_cat_ids and get_gt_labels.
Not implemented get_cat_ids, KFoldDataset can't use with ClassBalancedDataset for example.
Not implemented get_gt_labels, can't calculate confusion matrix like #598.

## Modification

Simply implemented these methods to KFoldDataset.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
