### PR TITLE
[Docs] Fix logo url link from mmocr to mmclassification.

### DIFF
--- a/docs/zh_CN/conf.py
+++ b/docs/zh_CN/conf.py
@@ -88,7 +88,7 @@ html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
 #
 html_theme_options = {
     'logo_url':
-    'https://mmocr.readthedocs.io/zh_CN/latest/',
+    'https://mmclassification.readthedocs.io/zh_CN/latest/',
     'menu': [
         {
             'name': 'GitHub',


### PR DESCRIPTION
## Motivation

When i read the mmclassification zh_CN docs, i click the logo on left top, which redirect me to mmocr.readthedocs.io, after reading the source, i find it was a little bug

## Modification

i modify the file in docs/zh_CN/conf.py :91, and modify the link from `https://mmocr.readthedocs.io/zh_CN/latest/` to `https://mmclassification.readthedocs.io/zh_CN/latest/`

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.