### PR TITLE
[Feature] add lazy linear head

### DIFF
--- a/mmcls/models/heads/conformer_head.py
+++ b/mmcls/models/heads/conformer_head.py
@@ -1,9 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import warnings
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn.utils.weight_init import trunc_normal_
+from mmcv.utils import digit_version
 
 from ..builder import HEADS
 from .cls_head import ClsHead
@@ -43,6 +45,9 @@ class ConformerHead(ClsHead):
                 f'num_classes={num_classes} must be a positive integer')
 
         if self.lazy_linear:
+            if digit_version(torch.__version__) < digit_version('1.8.0'):
+                raise RuntimeError(
+                    'torch.nn.LazyLinear is not available before 1.8.0')
             warnings.warn('For ConformerHead with lazy_linear=True, '
                           f'in_channels={in_channels} and '
                           f'init_cfg={self.init_cfg} is ignored and '

--- a/mmcls/models/heads/deit_head.py
+++ b/mmcls/models/heads/deit_head.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import warnings
+
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -12,7 +14,13 @@ class DeiTClsHead(VisionTransformerClsHead):
 
     def __init__(self, *args, **kwargs):
         super(DeiTClsHead, self).__init__(*args, **kwargs)
-        if self.hidden_dim is None:
+        if self.lazy_linear:
+            warnings.warn('For DeiTClsHead with lazy_linear=True, '
+                          f'in_channels={self.in_channels} and '
+                          f'init_cfg={self.init_cfg} is ignored and '
+                          f'calculated automatically.')
+            head_dist = nn.LazyLinear(self.num_classes)
+        elif self.hidden_dim is None:
             head_dist = nn.Linear(self.in_channels, self.num_classes)
         else:
             head_dist = nn.Linear(self.hidden_dim, self.num_classes)

--- a/mmcls/models/heads/deit_head.py
+++ b/mmcls/models/heads/deit_head.py
@@ -1,8 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import warnings
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from mmcv.utils import digit_version
 
 from mmcls.utils import get_root_logger
 from ..builder import HEADS
@@ -15,6 +17,9 @@ class DeiTClsHead(VisionTransformerClsHead):
     def __init__(self, *args, **kwargs):
         super(DeiTClsHead, self).__init__(*args, **kwargs)
         if self.lazy_linear:
+            if digit_version(torch.__version__) < digit_version('1.8.0'):
+                raise RuntimeError(
+                    'torch.nn.LazyLinear is not available before 1.8.0')
             warnings.warn('For DeiTClsHead with lazy_linear=True, '
                           f'in_channels={self.in_channels} and '
                           f'init_cfg={self.init_cfg} is ignored and '

--- a/mmcls/models/heads/linear_head.py
+++ b/mmcls/models/heads/linear_head.py
@@ -1,8 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import warnings
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from mmcv.utils import digit_version
 
 from ..builder import HEADS
 from .cls_head import ClsHead
@@ -40,6 +42,9 @@ class LinearClsHead(ClsHead):
                 f'num_classes={num_classes} must be a positive integer')
 
         if self.lazy_linear:
+            if digit_version(torch.__version__) < digit_version('1.8.0'):
+                raise RuntimeError(
+                    'torch.nn.LazyLinear is not available before 1.8.0')
             warnings.warn('For LinearClsHead with lazy_linear=True, '
                           f'in_channels={in_channels} and '
                           f'init_cfg={self.init_cfg}  is ignored and '

--- a/mmcls/models/heads/multi_label_linear_head.py
+++ b/mmcls/models/heads/multi_label_linear_head.py
@@ -3,6 +3,7 @@ import warnings
 
 import torch
 import torch.nn as nn
+from mmcv.utils import digit_version
 
 from ..builder import HEADS
 from .multi_label_head import MultiLabelClsHead
@@ -44,6 +45,9 @@ class MultiLabelLinearClsHead(MultiLabelClsHead):
         self.lazy_linear = lazy_linear
 
         if self.lazy_linear:
+            if digit_version(torch.__version__) < digit_version('1.8.0'):
+                raise RuntimeError(
+                    'torch.nn.LazyLinear is not available before 1.8.0')
             warnings.warn('For MultiLabelLinearClsHead with lazy_linear=True, '
                           f'in_channels={in_channels} and '
                           f'init_cfg={self.init_cfg}  is ignored and '

--- a/mmcls/models/heads/stacked_head.py
+++ b/mmcls/models/heads/stacked_head.py
@@ -2,10 +2,12 @@
 import warnings
 from typing import Dict, Sequence
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import build_activation_layer, build_norm_layer
 from mmcv.runner import BaseModule, ModuleList
+from mmcv.utils import digit_version
 
 from ..builder import HEADS
 from .cls_head import ClsHead
@@ -79,6 +81,9 @@ class StackedLinearClsHead(ClsHead):
                  **kwargs):
         super(StackedLinearClsHead, self).__init__(**kwargs)
         if lazy_linear:
+            if digit_version(torch.__version__) < digit_version('1.8.0'):
+                raise RuntimeError(
+                    'torch.nn.LazyLinear is not available before 1.8.0')
             warnings.warn(
                 'For StackedLinearClsHead with lazy_linear=True, '
                 f'in_channels={in_channels} and init_cfg={self.init_cfg} '

--- a/mmcls/models/heads/vision_transformer_head.py
+++ b/mmcls/models/heads/vision_transformer_head.py
@@ -3,11 +3,13 @@ import math
 import warnings
 from collections import OrderedDict
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import build_activation_layer
 from mmcv.cnn.utils.weight_init import trunc_normal_
 from mmcv.runner import Sequential
+from mmcv.utils import digit_version
 
 from ..builder import HEADS
 from .cls_head import ClsHead
@@ -38,6 +40,11 @@ class VisionTransformerClsHead(ClsHead):
                  **kwargs):
         super(VisionTransformerClsHead, self).__init__(
             init_cfg=init_cfg, *args, **kwargs)
+        if lazy_linear:
+            if digit_version(torch.__version__) < digit_version('1.8.0'):
+                raise RuntimeError(
+                    'torch.nn.LazyLinear is not available before 1.8.0')
+
         self.in_channels = in_channels
         self.num_classes = num_classes
         self.hidden_dim = hidden_dim

--- a/tests/test_models/test_heads.py
+++ b/tests/test_models/test_heads.py
@@ -233,6 +233,14 @@ def test_vit_head():
     assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
     assert losses['loss'].item() > 0
 
+    # test vit head forward with lazy_linear=True
+    head = VisionTransformerClsHead(10, 0, lazy_linear=True)
+    head.init_weights()
+    losses = head.forward_train(fake_features, fake_gt_label)
+    assert not hasattr(head.layers, 'pre_logits')
+    assert not hasattr(head.layers, 'act')
+    assert losses['loss'].item() > 0
+
     # test vit head forward with hidden layer and lazy_linear=True
     head = VisionTransformerClsHead(10, 0, hidden_dim=20, lazy_linear=True)
     head.init_weights()
@@ -282,6 +290,11 @@ def test_conformer_head():
     head.init_weights()
     losses = head.forward_train(fake_features, fake_gt_label)
     assert losses['loss'].item() > 0
+
+    # test conformer head init_weights
+    head = ConformerHead(num_classes=10, in_channels=[64, 96])
+    head.init_weights()
+    assert abs(head.conv_cls_head.weight).sum() > 0
 
     # test simple_test with post_process
     pred = head.simple_test(fake_features)

--- a/tests/test_models/test_heads.py
+++ b/tests/test_models/test_heads.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from mmcv.utils import digit_version
 
 from mmcls.models.heads import (ClsHead, ConformerHead, DeiTClsHead,
                                 LinearClsHead, MultiLabelClsHead,
@@ -62,11 +63,12 @@ def test_linear_head(feat):
     losses = head.forward_train(feat, fake_gt_label)
     assert losses['loss'].item() > 0
 
-    # test LinearClsHead forward with lazy_linear=True
-    head = LinearClsHead(10, 0, lazy_linear=True)
-    head.init_weights()
-    losses = head.forward_train(feat, fake_gt_label)
-    assert losses['loss'].item() > 0
+    if digit_version(torch.__version__) >= digit_version('1.8.0'):
+        # test LinearClsHead forward with lazy_linear=True
+        head = LinearClsHead(10, 0, lazy_linear=True)
+        head.init_weights()
+        losses = head.forward_train(feat, fake_gt_label)
+        assert losses['loss'].item() > 0
 
     # test init weights
     head = LinearClsHead(10, 3)
@@ -132,11 +134,12 @@ def test_multilabel_linear_head(feat):
     losses = head.forward_train(feat, fake_gt_label)
     assert losses['loss'].item() > 0
 
-    # test MultiLabelLinearClsHead forward with lazy_linear=True
-    head = MultiLabelLinearClsHead(10, 0, lazy_linear=True)
-    head.init_weights()
-    losses = head.forward_train(feat, fake_gt_label)
-    assert losses['loss'].item() > 0
+    if digit_version(torch.__version__) >= digit_version('1.8.0'):
+        # test MultiLabelLinearClsHead forward with lazy_linear=True
+        head = MultiLabelLinearClsHead(10, 0, lazy_linear=True)
+        head.init_weights()
+        losses = head.forward_train(feat, fake_gt_label)
+        assert losses['loss'].item() > 0
 
     # test simple_test with post_process
     pred = head.simple_test(feat)
@@ -178,12 +181,13 @@ def test_stacked_linear_cls_head(feat):
     losses = head.forward_train(feat, fake_gt_label)
     assert losses['loss'].item() > 0
 
-    # test forward with lazy_linear=True
-    head = StackedLinearClsHead(10, 0, mid_channels=[20], lazy_linear=True)
-    head.init_weights()
+    if digit_version(torch.__version__) >= digit_version('1.8.0'):
+        # test forward with lazy_linear=True
+        head = StackedLinearClsHead(10, 0, mid_channels=[20], lazy_linear=True)
+        head.init_weights()
 
-    losses = head.forward_train(feat, fake_gt_label)
-    assert losses['loss'].item() > 0
+        losses = head.forward_train(feat, fake_gt_label)
+        assert losses['loss'].item() > 0
 
     # test simple_test with post_process
     pred = head.simple_test(feat)
@@ -233,20 +237,22 @@ def test_vit_head():
     assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
     assert losses['loss'].item() > 0
 
-    # test vit head forward with lazy_linear=True
-    head = VisionTransformerClsHead(10, 0, lazy_linear=True)
-    head.init_weights()
-    losses = head.forward_train(fake_features, fake_gt_label)
-    assert not hasattr(head.layers, 'pre_logits')
-    assert not hasattr(head.layers, 'act')
-    assert losses['loss'].item() > 0
+    if digit_version(torch.__version__) >= digit_version('1.8.0'):
+        # test vit head forward with lazy_linear=True
+        head = VisionTransformerClsHead(10, 0, lazy_linear=True)
+        head.init_weights()
+        losses = head.forward_train(fake_features, fake_gt_label)
+        assert not hasattr(head.layers, 'pre_logits')
+        assert not hasattr(head.layers, 'act')
+        assert losses['loss'].item() > 0
 
-    # test vit head forward with hidden layer and lazy_linear=True
-    head = VisionTransformerClsHead(10, 0, hidden_dim=20, lazy_linear=True)
-    head.init_weights()
-    losses = head.forward_train(fake_features, fake_gt_label)
-    assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
-    assert losses['loss'].item() > 0
+        # test vit head forward with hidden layer and lazy_linear=True
+        head = VisionTransformerClsHead(10, 0, hidden_dim=20, lazy_linear=True)
+        head.init_weights()
+        losses = head.forward_train(fake_features, fake_gt_label)
+        assert hasattr(head.layers, 'pre_logits') and hasattr(
+            head.layers, 'act')
+        assert losses['loss'].item() > 0
 
     # test vit head init_weights
     head = VisionTransformerClsHead(10, 100, hidden_dim=20)
@@ -285,11 +291,13 @@ def test_conformer_head():
     losses = head.forward_train(fake_features, fake_gt_label)
     assert losses['loss'].item() > 0
 
-    # test conformer head forward with lazy_linear=True
-    head = ConformerHead(num_classes=10, in_channels=[0, 0], lazy_linear=True)
-    head.init_weights()
-    losses = head.forward_train(fake_features, fake_gt_label)
-    assert losses['loss'].item() > 0
+    if digit_version(torch.__version__) >= digit_version('1.8.0'):
+        # test conformer head forward with lazy_linear=True
+        head = ConformerHead(
+            num_classes=10, in_channels=[0, 0], lazy_linear=True)
+        head.init_weights()
+        losses = head.forward_train(fake_features, fake_gt_label)
+        assert losses['loss'].item() > 0
 
     # test conformer head init_weights
     head = ConformerHead(num_classes=10, in_channels=[64, 96])
@@ -335,13 +343,15 @@ def test_deit_head():
     assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
     assert losses['loss'].item() > 0
 
-    # test deit head forward with hidden layer and lazy_linear=True
-    head = DeiTClsHead(
-        num_classes=10, in_channels=0, hidden_dim=20, lazy_linear=True)
-    head.init_weights()
-    losses = head.forward_train(fake_features, fake_gt_label)
-    assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
-    assert losses['loss'].item() > 0
+    if digit_version(torch.__version__) >= digit_version('1.8.0'):
+        # test deit head forward with hidden layer and lazy_linear=True
+        head = DeiTClsHead(
+            num_classes=10, in_channels=0, hidden_dim=20, lazy_linear=True)
+        head.init_weights()
+        losses = head.forward_train(fake_features, fake_gt_label)
+        assert hasattr(head.layers, 'pre_logits') and hasattr(
+            head.layers, 'act')
+        assert losses['loss'].item() > 0
 
     # test deit head init_weights
     head = DeiTClsHead(10, 100, hidden_dim=20)

--- a/tests/test_models/test_heads.py
+++ b/tests/test_models/test_heads.py
@@ -62,6 +62,12 @@ def test_linear_head(feat):
     losses = head.forward_train(feat, fake_gt_label)
     assert losses['loss'].item() > 0
 
+    # test LinearClsHead forward with lazy_linear=True
+    head = LinearClsHead(10, 0, lazy_linear=True)
+    head.init_weights()
+    losses = head.forward_train(feat, fake_gt_label)
+    assert losses['loss'].item() > 0
+
     # test init weights
     head = LinearClsHead(10, 3)
     head.init_weights()
@@ -126,6 +132,12 @@ def test_multilabel_linear_head(feat):
     losses = head.forward_train(feat, fake_gt_label)
     assert losses['loss'].item() > 0
 
+    # test MultiLabelLinearClsHead forward with lazy_linear=True
+    head = MultiLabelLinearClsHead(10, 0, lazy_linear=True)
+    head.init_weights()
+    losses = head.forward_train(feat, fake_gt_label)
+    assert losses['loss'].item() > 0
+
     # test simple_test with post_process
     pred = head.simple_test(feat)
     assert isinstance(pred, list) and len(pred) == 4
@@ -161,6 +173,13 @@ def test_stacked_linear_cls_head(feat):
     # test forward with default setting
     head = StackedLinearClsHead(
         num_classes=10, in_channels=5, mid_channels=[20])
+    head.init_weights()
+
+    losses = head.forward_train(feat, fake_gt_label)
+    assert losses['loss'].item() > 0
+
+    # test forward with lazy_linear=True
+    head = StackedLinearClsHead(10, 0, mid_channels=[20], lazy_linear=True)
     head.init_weights()
 
     losses = head.forward_train(feat, fake_gt_label)
@@ -214,6 +233,13 @@ def test_vit_head():
     assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
     assert losses['loss'].item() > 0
 
+    # test vit head forward with hidden layer and lazy_linear=True
+    head = VisionTransformerClsHead(10, 0, hidden_dim=20, lazy_linear=True)
+    head.init_weights()
+    losses = head.forward_train(fake_features, fake_gt_label)
+    assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
+    assert losses['loss'].item() > 0
+
     # test vit head init_weights
     head = VisionTransformerClsHead(10, 100, hidden_dim=20)
     head.init_weights()
@@ -248,6 +274,12 @@ def test_conformer_head():
 
     # test conformer head forward
     head = ConformerHead(num_classes=10, in_channels=[64, 96])
+    losses = head.forward_train(fake_features, fake_gt_label)
+    assert losses['loss'].item() > 0
+
+    # test conformer head forward with lazy_linear=True
+    head = ConformerHead(num_classes=10, in_channels=[0, 0], lazy_linear=True)
+    head.init_weights()
     losses = head.forward_train(fake_features, fake_gt_label)
     assert losses['loss'].item() > 0
 
@@ -290,11 +322,17 @@ def test_deit_head():
     assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
     assert losses['loss'].item() > 0
 
+    # test deit head forward with hidden layer and lazy_linear=True
+    head = DeiTClsHead(
+        num_classes=10, in_channels=0, hidden_dim=20, lazy_linear=True)
+    head.init_weights()
+    losses = head.forward_train(fake_features, fake_gt_label)
+    assert hasattr(head.layers, 'pre_logits') and hasattr(head.layers, 'act')
+    assert losses['loss'].item() > 0
+
     # test deit head init_weights
     head = DeiTClsHead(10, 100, hidden_dim=20)
     head.init_weights()
-    assert abs(head.layers.pre_logits.weight).sum() > 0
-
     head = DeiTClsHead(10, 100, hidden_dim=20)
     # test simple_test with post_process
     pred = head.simple_test(fake_features)


### PR DESCRIPTION
## Motivation

It is complicated to calculate the output channels of the backbone and set them as the input channels of the head.
One solution was to use nn.LazyLinear.
It can be used to automatically set the head input channel without specifying it.
One disadvantage is that it ignores init_cfg.

## Use cases

```
head = LinearClsHead(10, 0, lazy_linear=True)
head.init_weights()
losses = head.forward_train(feat, fake_gt_label)
assert losses['loss'].item() > 0
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
