### PR TITLE
[Fix] Fix the discontiguous output feature map of ConvNeXt.

### DIFF
--- a/mmcls/models/backbones/convnext.py
+++ b/mmcls/models/backbones/convnext.py
@@ -312,7 +312,7 @@ class ConvNeXt(BaseBackbone):
                     gap = x.mean([-2, -1], keepdim=True)
                     outs.append(norm_layer(gap).flatten(1))
                 else:
-                    outs.append(norm_layer(x))
+                    outs.append(norm_layer(x).contiguous())
 
         return tuple(outs)
 

--- a/mmcls/models/backbones/convnext.py
+++ b/mmcls/models/backbones/convnext.py
@@ -312,6 +312,8 @@ class ConvNeXt(BaseBackbone):
                     gap = x.mean([-2, -1], keepdim=True)
                     outs.append(norm_layer(gap).flatten(1))
                 else:
+                    # The output of LayerNorm2d may be discontiguous, which
+                    # may cause some problem in the downstream tasks
                     outs.append(norm_layer(x).contiguous())
 
         return tuple(outs)


### PR DESCRIPTION
## Motivation

The output feature map of ConvNeXt may be not contiguous, which may cause training problem in downstream tasks.

## Modification

Make the output feature map be contiguous.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
