### PR TITLE
[Enhance] Add extra dataloader settings in configs.

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -90,10 +90,10 @@ def train_model(model,
         sampler_cfg=cfg.get('sampler', None),
     )
     # The overall dataloader settings
-    loader_cfg = {
+    loader_cfg.update({
         k: v
         for k, v in cfg.data.items() if k not in ['train', 'val', 'test']
-    }
+    })
     # The specific dataloader settings
     train_loader_cfg = {**loader_cfg, **cfg.data.get('train_dataloader', {})}
 

--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -92,7 +92,10 @@ def train_model(model,
     # The overall dataloader settings
     loader_cfg.update({
         k: v
-        for k, v in cfg.data.items() if k not in ['train', 'val', 'test']
+        for k, v in cfg.data.items() if k not in [
+            'train', 'val', 'test', 'train_dataloader', 'val_dataloader',
+            'test_dataloader'
+        ]
     })
     # The specific dataloader settings
     train_loader_cfg = {**loader_cfg, **cfg.data.get('train_dataloader', {})}

--- a/tools/test.py
+++ b/tools/test.py
@@ -146,10 +146,10 @@ def main():
         round_up=True,
     )
     # The overall dataloader settings
-    loader_cfg = {
+    loader_cfg.update({
         k: v
         for k, v in cfg.data.items() if k not in ['train', 'val', 'test']
-    }
+    })
     test_loader_cfg = {
         **loader_cfg,
         'shuffle': False,  # Not shuffle by default

--- a/tools/test.py
+++ b/tools/test.py
@@ -148,7 +148,10 @@ def main():
     # The overall dataloader settings
     loader_cfg.update({
         k: v
-        for k, v in cfg.data.items() if k not in ['train', 'val', 'test']
+        for k, v in cfg.data.items() if k not in [
+            'train', 'val', 'test', 'train_dataloader', 'val_dataloader',
+            'test_dataloader'
+        ]
     })
     test_loader_cfg = {
         **loader_cfg,


### PR DESCRIPTION
## Motivation

In some situation, we need to use different dataloader settings like `samples_per_gpu` in train/val/test dataloader.

## Modification

Use `train_dataloader`, `val_dataloader` and `test_dataloader` settings in the `data` field to specify different arguments.

## Use cases (Optional)

```python
data = dict(
    samples_per_gpu=64,
    workers_per_gpu=4,
    train=dict(type='xxx', ...),
    val=dict(type='xxx', ...),
    test=dict(type='xxx', ...),
    # Use different batch size during inference.
    val_dataloader=dict(samples_per_gpu=8, workers_per_gpu=2),
    test_dataloader=dict(samples_per_gpu=8, workers_per_gpu=2),
)
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
