### PR TITLE
[Enhance] Improve CPE performance by reduce memory copy.

### DIFF
--- a/mmcls/models/utils/position_encoding.py
+++ b/mmcls/models/utils/position_encoding.py
@@ -32,7 +32,7 @@ class ConditionalPositionEncoding(BaseModule):
         H, W = hw_shape
         feat_token = x
         # convert (B, N, C) to (B, C, H, W)
-        cnn_feat = feat_token.transpose(1, 2).view(B, C, H, W)
+        cnn_feat = feat_token.transpose(1, 2).view(B, C, H, W).contiguous()
         if self.stride == 1:
             x = self.proj(cnn_feat) + cnn_feat
         else:


### PR DESCRIPTION
## Motivation

For position_encoding, the **self.proj**'s input is always a non-contiguous tensor, there has a performance issue when **self.stride == 1**, because PyTorch always has a contiguous conversion when convolution's input is not a contiguous tensor(https://github.com/pytorch/pytorch/blob/fa09099ba35fcd42347732ca3a5f8ddaf145da1b/aten/src/ATen/native/Convolution.cpp#L1093), and **add** also has a similar issue(the input from convolution is a contiguous tensor, but another input is non-contiguous tensor).

## Modification
This PR will do pre contiguous conversion before doing **convolution** and **add** computing.
