### PR TITLE
[Feature] Add `MultiTaskDataset` to support multi-task training.

### DIFF
--- a/docs/en/api/datasets.rst
+++ b/docs/en/api/datasets.rst
@@ -46,6 +46,11 @@ Base classes
 
 .. autoclass:: MultiLabelDataset
 
+Multi-Task Dataset
+------------------
+
+.. autoclass:: MultiTaskDataset
+
 Dataset Wrappers
 ----------------
 

--- a/docs/en/api/transforms.rst
+++ b/docs/en/api/transforms.rst
@@ -169,3 +169,7 @@ ToTensor
 Transpose
 ---------------------
 .. autoclass:: Transpose
+
+FormatMultiTaskLabels
+---------------------
+.. autoclass:: FormatMultiTaskLabels

--- a/mmcls/datasets/__init__.py
+++ b/mmcls/datasets/__init__.py
@@ -11,6 +11,7 @@ from .imagenet import ImageNet
 from .imagenet21k import ImageNet21k
 from .mnist import MNIST, FashionMNIST
 from .multi_label import MultiLabelDataset
+from .multi_task import MultiTaskDataset
 from .samplers import DistributedSampler, RepeatAugSampler
 from .voc import VOC
 
@@ -19,5 +20,6 @@ __all__ = [
     'VOC', 'MultiLabelDataset', 'build_dataloader', 'build_dataset',
     'DistributedSampler', 'ConcatDataset', 'RepeatDataset',
     'ClassBalancedDataset', 'DATASETS', 'PIPELINES', 'ImageNet21k', 'SAMPLERS',
-    'build_sampler', 'RepeatAugSampler', 'KFoldDataset', 'CUB', 'CustomDataset'
+    'build_sampler', 'RepeatAugSampler', 'KFoldDataset', 'CUB',
+    'CustomDataset', 'MultiTaskDataset'
 ]

--- a/mmcls/datasets/base_dataset.py
+++ b/mmcls/datasets/base_dataset.py
@@ -145,6 +145,24 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         Returns:
             dict: evaluation results
         """
+        results = np.vstack(results)
+        gt_labels = self.get_gt_labels()
+        if indices is not None:
+            gt_labels = gt_labels[indices]
+
+        return self.evaluate_single_label(
+            results=results,
+            gt_labels=gt_labels,
+            metric=metric,
+            metric_options=metric_options,
+            logger=logger)
+
+    @staticmethod
+    def evaluate_single_label(results,
+                              gt_labels,
+                              metric='accuracy',
+                              metric_options=None,
+                              logger=None):
         if metric_options is None:
             metric_options = {'topk': (1, 5)}
         if isinstance(metric, str):
@@ -154,11 +172,6 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         allowed_metrics = [
             'accuracy', 'precision', 'recall', 'f1_score', 'support'
         ]
-        eval_results = {}
-        results = np.vstack(results)
-        gt_labels = self.get_gt_labels()
-        if indices is not None:
-            gt_labels = gt_labels[indices]
         num_imgs = len(results)
         assert len(gt_labels) == num_imgs, 'dataset testing results should '\
             'be of the same length as gt_labels.'
@@ -171,6 +184,7 @@ class BaseDataset(Dataset, metaclass=ABCMeta):
         thrs = metric_options.get('thrs')
         average_mode = metric_options.get('average_mode', 'macro')
 
+        eval_results = {}
         if 'accuracy' in metrics:
             if thrs is not None:
                 acc = accuracy(results, gt_labels, topk=topk, thrs=thrs)

--- a/mmcls/datasets/multi_label.py
+++ b/mmcls/datasets/multi_label.py
@@ -44,6 +44,23 @@ class MultiLabelDataset(BaseDataset):
         Returns:
             dict: evaluation results
         """
+        results = np.vstack(results)
+        gt_labels = self.get_gt_labels()
+        if indices is not None:
+            gt_labels = gt_labels[indices]
+        return self.evaluate_multi_label(
+            results=results,
+            gt_labels=gt_labels,
+            metric=metric,
+            metric_options=metric_options,
+            logger=logger)
+
+    @staticmethod
+    def evaluate_multi_label(results,
+                             gt_labels,
+                             metric='mAP',
+                             metric_options=None,
+                             logger=None):
         if metric_options is None or metric_options == {}:
             metric_options = {'thr': 0.5}
 
@@ -53,10 +70,7 @@ class MultiLabelDataset(BaseDataset):
             metrics = metric
         allowed_metrics = ['mAP', 'CP', 'CR', 'CF1', 'OP', 'OR', 'OF1']
         eval_results = {}
-        results = np.vstack(results)
-        gt_labels = self.get_gt_labels()
-        if indices is not None:
-            gt_labels = gt_labels[indices]
+
         num_imgs = len(results)
         assert len(gt_labels) == num_imgs, 'dataset testing results should '\
             'be of the same length as gt_labels.'

--- a/mmcls/datasets/multi_task.py
+++ b/mmcls/datasets/multi_task.py
@@ -1,0 +1,507 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+import os.path as osp
+from collections import defaultdict
+from os import PathLike
+from typing import Dict, List, Optional, Sequence
+
+import mmcv
+import numpy as np
+from mmcv.fileio import FileClient
+from mmcv.utils.misc import is_list_of
+
+from .base_dataset import BaseDataset
+from .builder import DATASETS
+from .multi_label import MultiLabelDataset
+from .pipelines import Compose
+
+
+def expanduser(path):
+    if isinstance(path, (str, PathLike)):
+        return osp.expanduser(path)
+    else:
+        return path
+
+
+def isabs(uri):
+    return osp.isabs(uri) or ('://' in uri)
+
+
+@DATASETS.register_module()
+class MultiTaskDataset:
+    """Custom dataset for multi-task dataset.
+
+    To use the dataset, please generate and provide an annotation file in the
+    below format:
+
+    .. code-block:: json
+
+        {
+          "metainfo": {
+            "tasks":
+              [
+                {"name": "gender",
+                 "type": "single-label",
+                 "categories": ["male", "female"]},
+                {"name": "wear",
+                 "type": "multi-label",
+                 "categories": ["shirt", "coat", "jeans", "pants"]}
+              ]
+          },
+          "data_list": [
+            {
+              "img_path": "a.jpg",
+              "gender_img_label": 0,
+              "wear_img_label": [1, 0, 1, 0]
+            },
+            {
+              "img_path": "b.jpg",
+              "gender_img_label": 1,
+              "wear_img_label": [0, 1, 0, 1]
+            }
+          ]
+        }
+
+    Assume we put our dataset in the ``data/mydataset`` folder in the
+    repository and organize it as the below format: ::
+
+        mmclassification/
+        └── data
+            └── mydataset
+                ├── annotation
+                │   ├── train.json
+                │   ├── test.json
+                │   └── val.json
+                ├── train
+                │   ├── a.jpg
+                │   └── ...
+                ├── test
+                │   ├── b.jpg
+                │   └── ...
+                └── val
+                    ├── c.jpg
+                    └── ...
+
+    We can use the below config to build datasets:
+
+    .. code:: python
+
+        >>> from mmcls.datasets import build_dataset
+        >>> train_cfg = dict(
+        ...     type="MultiTaskDataset",
+        ...     ann_file="annotation/train.json",
+        ...     data_root="data/mydataset",
+        ...     # The `img_path` field in the train annotation file is relative
+        ...     # to the `train` folder.
+        ...     data_prefix='train',
+        ... )
+        >>> train_dataset = build_dataset(train_cfg)
+
+    Or we can put all files in the same folder: ::
+
+        mmclassification/
+        └── data
+            └── mydataset
+                 ├── train.json
+                 ├── test.json
+                 ├── val.json
+                 ├── a.jpg
+                 ├── b.jpg
+                 ├── c.jpg
+                 └── ...
+
+    And we can use the below config to build datasets:
+
+    .. code:: python
+
+        >>> from mmcls.datasets import build_dataset
+        >>> train_cfg = dict(
+        ...     type="MultiTaskDataset",
+        ...     ann_file="train.json",
+        ...     data_root="data/mydataset",
+        ...     # the `data_prefix` is not required since all paths are
+        ...     # relative to the `data_root`.
+        ... )
+        >>> train_dataset = build_dataset(train_cfg)
+
+
+    Args:
+        ann_file (str): The annotation file path. It can be either absolute
+            path or relative path to the ``data_root``.
+        metainfo (dict, optional): The extra meta information. It should be
+            a dict with the same format as the ``"metainfo"`` field in the
+            annotation file. Defaults to None.
+        data_root (str, optional): The root path of the data directory. It's
+            the prefix of the ``data_prefix`` and the ``ann_file``. And it can
+            be a remote path like "s3://openmmlab/xxx/". Defaults to None.
+        data_prefix (str, optional): The base folder relative to the
+            ``data_root`` for the ``"img_path"`` field in the annotation file.
+            Defaults to None.
+        pipeline (Sequence[dict]): A list of dict, where each element
+            represents a operation defined in :mod:`mmcls.datasets.pipelines`.
+            Defaults to an empty tuple.
+        test_mode (bool): in train mode or test mode. Defaults to False.
+        file_client_args (dict, optional): Arguments to instantiate a
+            FileClient. See :class:`mmcv.fileio.FileClient` for details.
+            If None, automatically inference from the ``data_root``.
+            Defaults to None.
+    """
+    METAINFO = dict()
+
+    def __init__(self,
+                 ann_file: str,
+                 metainfo: Optional[dict] = None,
+                 data_root: Optional[str] = None,
+                 data_prefix: Optional[str] = None,
+                 pipeline: Sequence = (),
+                 test_mode: bool = False,
+                 file_client_args: Optional[dict] = None):
+
+        self.data_root = expanduser(data_root)
+
+        # Inference the file client
+        if self.data_root is not None:
+            file_client = FileClient.infer_client(
+                file_client_args, uri=self.data_root)
+        else:
+            file_client = FileClient(file_client_args)
+        self.file_client: FileClient = file_client
+
+        self.ann_file = self._join_root(expanduser(ann_file))
+        self.data_prefix = self._join_root(data_prefix)
+
+        self.test_mode = test_mode
+        self.pipeline = Compose(pipeline)
+        self.data_list = self.load_data_list(self.ann_file, metainfo)
+
+    def _join_root(self, path):
+        """Join ``self.data_root`` with the specified path.
+
+        If the path is an absolute path, just return the path. And if the
+        path is None, return ``self.data_root``.
+
+        Examples:
+            >>> self.data_root = 'a/b/c'
+            >>> self._join_root('d/e/')
+            'a/b/c/d/e'
+            >>> self._join_root('https://openmmlab.com')
+            'https://openmmlab.com'
+            >>> self._join_root(None)
+            'a/b/c'
+        """
+        if path is None:
+            return self.data_root
+        if isabs(path):
+            return path
+
+        joined_path = self.file_client.join_path(self.data_root, path)
+        return joined_path
+
+    @classmethod
+    def _get_meta_info(cls, in_metainfo: dict = None) -> dict:
+        """Collect meta information from the dictionary of meta.
+
+        Args:
+            in_metainfo (dict): Meta information dict.
+
+        Returns:
+            dict: Parsed meta information.
+        """
+        # `cls.METAINFO` will be overwritten by in_meta
+        metainfo = copy.deepcopy(cls.METAINFO)
+        if in_metainfo is None:
+            return metainfo
+
+        metainfo.update(in_metainfo)
+
+        # Format check
+        assert 'tasks' in metainfo, \
+            'Please specify the `tasks` in the `metainfo` argument or ' \
+            'the `metainfo` field in the annotation file.'
+        tasks = metainfo['tasks']
+        assert is_list_of(tasks, dict), \
+            'Every task of `tasks` in the `metainfo` should be a dict.'
+        for task in tasks:
+            for field in ['name', 'categories', 'type']:
+                assert field in task, \
+                    f'Missing "{field}" in some tasks meta information.'
+
+        return metainfo
+
+    def load_data_list(self, ann_file, metainfo_override=None):
+        """Load annotations from an annotation file.
+
+        Args:
+            ann_file (str): Absolute annotation file path if ``self.root=None``
+                or relative path if ``self.root=/path/to/data/``.
+
+        Returns:
+            list[dict]: A list of annotation.
+        """
+        annotations = mmcv.load(ann_file)
+        if not isinstance(annotations, dict):
+            raise TypeError(f'The annotations loaded from annotation file '
+                            f'should be a dict, but got {type(annotations)}!')
+        if 'data_list' not in annotations:
+            raise ValueError('The annotation file must have the `data_list` '
+                             'field.')
+        metainfo = annotations.get('metainfo', {})
+        raw_data_list = annotations['data_list']
+
+        # Set meta information.
+        assert isinstance(metainfo, dict), 'The `metainfo` field in the '\
+            f'annotation file should be a dict, but got {type(metainfo)}'
+        if metainfo_override is not None:
+            assert isinstance(metainfo_override, dict), 'The `metainfo` ' \
+                f'argument should be a dict, but got {type(metainfo_override)}'
+            metainfo.update(metainfo_override)
+        self._metainfo = self._get_meta_info(metainfo)
+
+        data_list = []
+        for i, raw_data in enumerate(raw_data_list):
+            try:
+                data_list.append(self.parse_data_info(raw_data))
+            except AssertionError as e:
+                raise RuntimeError(
+                    f'The format check fails during parse the item {i} of '
+                    f'the annotation file with error: {e}')
+        return data_list
+
+    def parse_data_info(self, raw_data):
+        """Parse raw annotation to target format.
+
+        This method will return a dict which contains the data information of a
+        sample.
+
+        Args:
+            raw_data (dict): Raw data information load from ``ann_file``
+
+        Returns:
+            dict: Parsed annotation.
+        """
+        assert isinstance(raw_data, dict), \
+            f'The item should be a dict, but got {type(raw_data)}'
+        assert 'img_path' in raw_data, \
+            "The item doesn't have `img_path` field."
+        data = dict(
+            img_prefix=self.data_root,
+            img_info=dict(filename=raw_data['img_path']),
+        )
+
+        for task in self._metainfo['tasks']:
+            label_key = task['name'] + '_img_label'
+            task_type = task['type']
+            assert label_key in raw_data, \
+                f"The item doesn't have `{label_key}` field."
+            if task_type == 'single-label':
+                data[label_key] = np.array(raw_data[label_key], dtype=np.int64)
+                assert data[label_key].ndim == 0, \
+                    'The label of single-label task should be a single number.'
+            elif task_type == 'multi-label':
+                data[label_key] = np.array(raw_data[label_key], dtype=np.int8)
+                assert (data[label_key] <= 1).all(), \
+                    'The label of multi-label task should be one-hot format.'
+
+        return data
+
+    @property
+    def class_to_idx(self):
+        """Map mapping class name to class index.
+
+        Returns:
+            Dict[str, dict]: The mapping from class name to class index of
+            each tasks.
+        """
+
+        mapping_dict = {}
+        for task in self.metainfo['tasks']:
+            name = task['name']
+            categories = task['categories']
+            mapping_dict[name] = {
+                category: i
+                for i, category in enumerate(categories)
+            }
+        return mapping_dict
+
+    @property
+    def metainfo(self) -> dict:
+        """Get meta information of dataset.
+
+        Returns:
+            dict: meta information collected from ``cls.METAINFO``,
+            annotation file and metainfo argument during instantiation.
+        """
+        return copy.deepcopy(self._metainfo)
+
+    @property
+    def CLASSES(self) -> dict:
+        """Get the classes information of dataset.
+
+        Returns:
+            Dict[str, list]: The categories list for each task.
+        """
+        return {
+            task['name']: task['categories']
+            for task in self._metainfo['tasks']
+        }
+
+    def get_gt_labels(self):
+        """Get all ground-truth labels (categories).
+
+        Returns:
+            Dict[str, np.ndarray]: categories of all images for each task.
+        """
+
+        gt_labels_dict = defaultdict(list)
+        for data in self.data_list:
+            for task in self.metainfo['tasks']:
+                name = task['name']
+                gt_labels_dict[name].append(data[f'{name}_img_label'])
+        for k, v in gt_labels_dict.items():
+            gt_labels_dict[k] = np.array(v)
+        return dict(gt_labels_dict)
+
+    def get_cat_ids(self, idx: int) -> Dict[str, List[int]]:
+        """Get the category ids by index.
+
+        Args:
+            idx (int): Index of data.
+
+        Returns:
+            Dict[str, List[int]]: Image category ids of specified index for
+            each task.
+        """
+        data = self.data_list[idx]
+        cat_ids_dict = {}
+        for task in self.metainfo['tasks']:
+            name = task['name']
+            task_type = task['type']
+            gt_label = data[f'{name}_img_label']
+            if task_type == 'single-label':
+                cat_ids_dict[name] = [int(gt_label)]
+            elif task_type == 'multi-label':
+                cat_ids_dict[name] = np.where(gt_label == 1)[0].tolist()
+
+        return cat_ids_dict
+
+    def prepare_data(self, idx):
+        """Get data processed by ``self.pipeline``.
+
+        Args:
+            idx (int): The index of ``data_info``.
+
+        Returns:
+            Any: Depends on ``self.pipeline``.
+        """
+        results = copy.deepcopy(self.data_list[idx])
+        return self.pipeline(results)
+
+    def __len__(self):
+        """Get the length of the whole dataset.
+
+        Returns:
+            int: The length of filtered dataset.
+        """
+        return len(self.data_list)
+
+    def __getitem__(self, idx):
+        """Get the idx-th image and data information of dataset after
+        ``self.pipeline``.
+
+        Args:
+            idx (int): The index of of the data.
+
+        Returns:
+            dict: The idx-th image and data information after
+            ``self.pipeline``.
+        """
+        return self.prepare_data(idx)
+
+    def evaluate(self,
+                 results,
+                 metric=None,
+                 metric_options=None,
+                 indices=None,
+                 logger=None):
+        """Evaluate the dataset.
+
+        Args:
+            results (list): Testing results of the dataset.
+            metric (Dict[str, str | list[str]], optional): Metrics for each
+                task to be evaluated. Defaults to None, which means to use the
+                default metrics for every kinds of tasks.
+            metric_options (Dict[str, dict], optional): Options for calculating
+                metrics. Allowed keys for single-label tasks can be found in
+                the :class:`BaseDataset` and for multi-label tasks can be found
+                in the :class:`MultiLabelDataset`. Defaults to None.
+            indices (list, optional): The indices of samples corresponding to
+                the results. Defaults to None.
+            logger (logging.Logger | str, optional): Logger used for printing
+                related information during evaluation. Defaults to None.
+
+        Returns:
+            dict: evaluation results
+        """
+        eval_results = {}
+        gt_labels_dict = self.get_gt_labels()
+        results_dict = defaultdict(list)
+        for result in results:
+            for task in self.metainfo['tasks']:
+                name = task['name']
+                results_dict[name].append(result[name])
+
+        for task in self.metainfo['tasks']:
+            name = task['name']
+            task_type = task['type']
+            gt_labels = gt_labels_dict[name]
+            if indices is not None:
+                gt_labels = gt_labels[indices]
+            if task_type == 'single-label':
+                eval_func = BaseDataset.evaluate_single_label
+            elif task_type == 'multi-label':
+                eval_func = MultiLabelDataset.evaluate_multi_label
+
+            # To enable default values of `metric` and `metric_options`.
+            eval_args = dict(
+                results=np.vstack(results_dict[name]),
+                gt_labels=gt_labels,
+                logger=logger)
+            if metric is not None and name in metric:
+                eval_args['metric'] = metric[name]
+            if metric_options is not None and name in metric_options:
+                eval_args['metric_options'] = metric_options[name]
+
+            eval_result = eval_func(**eval_args)
+            for k, v in eval_result.items():
+                eval_results[f'{name}_{k}'] = v
+
+        return eval_results
+
+    def __repr__(self):
+        """Print the basic information of the dataset.
+
+        Returns:
+            str: Formatted string.
+        """
+        head = 'Dataset ' + self.__class__.__name__
+        body = [f'Number of samples: \t{self.__len__()}']
+        if self.data_root is not None:
+            body.append(f'Root location: \t{self.data_root}')
+        body.append(f'Annotation file: \t{self.ann_file}')
+        if self.data_prefix is not None:
+            body.append(f'Prefix of images: \t{self.data_prefix}')
+        # -------------------- extra repr --------------------
+        tasks = self.metainfo['tasks']
+        body.append(f'For {len(tasks)} tasks')
+        for task in tasks:
+            body.append(f'    {task["name"]} ({len(task["categories"])} '
+                        f'categories, {task["type"]})')
+        # ----------------------------------------------------
+
+        if len(self.pipeline.transforms) > 0:
+            body.append('With transforms:')
+            for t in self.pipeline.transforms:
+                body.append(f'    {t}')
+
+        lines = [head] + [' ' * 4 + line for line in body]
+        return '\n'.join(lines)

--- a/mmcls/datasets/pipelines/__init__.py
+++ b/mmcls/datasets/pipelines/__init__.py
@@ -4,8 +4,8 @@ from .auto_augment import (AutoAugment, AutoContrast, Brightness,
                            Posterize, RandAugment, Rotate, Sharpness, Shear,
                            Solarize, SolarizeAdd, Translate)
 from .compose import Compose
-from .formatting import (Collect, ImageToTensor, ToNumpy, ToPIL, ToTensor,
-                         Transpose, to_tensor)
+from .formatting import (Collect, FormatMultiTaskLabels, ImageToTensor,
+                         ToNumpy, ToPIL, ToTensor, Transpose, to_tensor)
 from .loading import LoadImageFromFile
 from .transforms import (CenterCrop, ColorJitter, Lighting, Normalize, Pad,
                          RandomCrop, RandomErasing, RandomFlip,
@@ -18,5 +18,6 @@ __all__ = [
     'RandomGrayscale', 'Shear', 'Translate', 'Rotate', 'Invert',
     'ColorTransform', 'Solarize', 'Posterize', 'AutoContrast', 'Equalize',
     'Contrast', 'Brightness', 'Sharpness', 'AutoAugment', 'SolarizeAdd',
-    'Cutout', 'RandAugment', 'Lighting', 'ColorJitter', 'RandomErasing', 'Pad'
+    'Cutout', 'RandAugment', 'Lighting', 'ColorJitter', 'RandomErasing', 'Pad',
+    'FormatMultiTaskLabels'
 ]

--- a/tests/data/dataset/multi-task.json
+++ b/tests/data/dataset/multi-task.json
@@ -1,0 +1,33 @@
+{
+  "metainfo": {
+    "tasks": [
+      {
+        "name": "gender",
+        "categories": ["male", "female"],
+        "type": "single-label"
+      },
+      {
+        "name": "wear",
+        "categories": ["shirt", "coat", "jeans", "pants"],
+        "type": "multi-label"
+      }
+    ]
+  },
+  "data_list": [
+    {
+      "img_path": "a/1.JPG",
+      "gender_img_label": 0,
+      "wear_img_label": [1, 0, 1, 0]
+    },
+    {
+      "img_path": "b/2.jpeg",
+      "gender_img_label": 0,
+      "wear_img_label": [1, 0, 1, 0]
+    },
+    {
+      "img_path": "b/subb/3.jpg",
+      "gender_img_label": 1,
+      "wear_img_label": [0, 1, 0, 1]
+    }
+  ]
+}

--- a/tests/test_data/test_datasets/test_multi_task.py
+++ b/tests/test_data/test_datasets/test_multi_task.py
@@ -1,0 +1,266 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
+import tempfile
+from unittest import TestCase
+
+import mmcv
+import numpy as np
+
+from mmcls.datasets import DATASETS
+
+ASSETS_ROOT = osp.abspath(
+    osp.join(osp.dirname(__file__), '../../data/dataset'))
+
+
+class TestMultiTaskDataset(TestCase):
+    DATASET_TYPE = 'MultiTaskDataset'
+
+    DEFAULT_ARGS = dict(
+        data_root=ASSETS_ROOT,
+        ann_file=osp.join(ASSETS_ROOT, 'multi-task.json'),
+        pipeline=[])
+
+    def test_metainfo(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+
+        # Test default behavior
+        dataset = dataset_class(**self.DEFAULT_ARGS)
+        metainfo = {
+            'tasks': [{
+                'name': 'gender',
+                'categories': ['male', 'female'],
+                'type': 'single-label'
+            }, {
+                'name': 'wear',
+                'categories': ['shirt', 'coat', 'jeans', 'pants'],
+                'type': 'multi-label'
+            }]
+        }
+        self.assertDictEqual(dataset.metainfo, metainfo)
+        self.assertEqual(
+            dataset.CLASSES, {
+                'gender': ['male', 'female'],
+                'wear': ['shirt', 'coat', 'jeans', 'pants']
+            })
+        self.assertFalse(dataset.test_mode)
+
+        # Test manually specify setting metainfo
+        metainfo = {
+            'tasks': [{
+                'name': 'gender',
+                'categories': ['a', 'b'],
+                'type': 'single-label'
+            }, {
+                'name': 'wear',
+                'categories': ['c', 'd', 'e'],
+                'type': 'multi-label'
+            }]
+        }
+        cfg = {**self.DEFAULT_ARGS, 'metainfo': metainfo}
+        dataset = dataset_class(**cfg)
+        self.assertDictEqual(dataset.metainfo, metainfo)
+        self.assertDictEqual(dataset.CLASSES, {
+            'gender': ['a', 'b'],
+            'wear': ['c', 'd', 'e']
+        })
+
+        # Test invalid metainfo
+        cfg = {**self.DEFAULT_ARGS, 'metainfo': ['a', 'b']}
+        with self.assertRaisesRegex(AssertionError, "got <class 'list'>"):
+            dataset_class(**cfg)
+
+        # Test annotation file without metainfo
+        tmpdir = tempfile.TemporaryDirectory()
+        new_annotation = mmcv.load(dataset.ann_file)
+        del new_annotation['metainfo']
+        new_ann_file = osp.abspath(osp.join(tmpdir.name, 'ann_file.json'))
+        mmcv.dump(new_annotation, new_ann_file)
+        cfg = {**self.DEFAULT_ARGS, 'ann_file': new_ann_file}
+        with self.assertRaisesRegex(AssertionError, 'specify the `tasks`'):
+            dataset_class(**cfg)
+
+        # Test wrong task type
+        cfg['metainfo'] = {'tasks': [['a', 'b'], ['d', 'e']]}
+        with self.assertRaisesRegex(AssertionError, 'should be a dict'):
+            dataset_class(**cfg)
+
+        # Test incomplete metainfo
+        cfg['metainfo'] = {
+            'tasks': [{
+                'name': 'gender',
+                'categories': ['a', 'b'],
+            }]
+        }
+        with self.assertRaisesRegex(AssertionError, 'Missing "type"'):
+            dataset_class(**cfg)
+
+        tmpdir.cleanup()
+
+    def test_data_root(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+
+        # Test relative ann_file
+        cfg = {**self.DEFAULT_ARGS, 'ann_file': 'multi-task.json'}
+        dataset = dataset_class(**cfg)
+        self.assertEqual(dataset.data_root, ASSETS_ROOT)
+        self.assertEqual(dataset.ann_file,
+                         osp.join(dataset.data_root, 'multi-task.json'))
+
+        # Test relative data_prefix
+        cfg = {**self.DEFAULT_ARGS, 'data_prefix': 'train'}
+        dataset = dataset_class(**cfg)
+        self.assertEqual(dataset.data_prefix,
+                         osp.join(dataset.data_root, 'train'))
+
+        # Test no data_prefix
+        cfg = {**self.DEFAULT_ARGS, 'data_prefix': None}
+        dataset = dataset_class(**cfg)
+        self.assertEqual(dataset.data_prefix, dataset.data_root)
+
+    def test_parse_data_info(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+        dataset = dataset_class(**self.DEFAULT_ARGS)
+
+        data = dataset.parse_data_info({
+            'img_path': 'a.jpg',
+            'gender_img_label': 0,
+            'wear_img_label': [1, 0, 1, 0]
+        })
+        self.assertDictContainsSubset(
+            {
+                'img_prefix': ASSETS_ROOT,
+                'img_info': {
+                    'filename': 'a.jpg'
+                }
+            }, data)
+        np.testing.assert_equal(data['gender_img_label'],
+                                np.array(0, dtype=np.int64))
+        np.testing.assert_equal(data['wear_img_label'],
+                                np.array([1, 0, 1, 0], dtype=np.int8))
+
+        # Test invalid type
+        with self.assertRaisesRegex(AssertionError, "got <class 'str'>"):
+            dataset.parse_data_info('hi')
+
+        # Test missing path
+        with self.assertRaisesRegex(AssertionError, 'have `img_path` field'):
+            dataset.parse_data_info({
+                'gender_img_label': 0,
+                'wear_img_label': [1, 0, 1, 0]
+            })
+
+        # Test missing label
+        with self.assertRaisesRegex(AssertionError,
+                                    'have `gender_img_label` field'):
+            dataset.parse_data_info({
+                'img_path': 'a.jpg',
+                'wear_img_label': [1, 0, 1, 0]
+            })
+
+        # Test invalid label type
+        with self.assertRaisesRegex(AssertionError, 'a single number'):
+            dataset.parse_data_info({
+                'img_path': 'a.jpg',
+                'gender_img_label': [0, 1],
+                'wear_img_label': [1, 0, 1, 0]
+            })
+        with self.assertRaisesRegex(AssertionError, 'one-hot format'):
+            dataset.parse_data_info({
+                'img_path': 'a.jpg',
+                'gender_img_label': 0,
+                'wear_img_label': [1, 2, 3, 4]
+            })
+
+    def test_get_cat_ids(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+        dataset = dataset_class(**self.DEFAULT_ARGS)
+
+        cat_ids = dataset.get_cat_ids(0)
+        self.assertIsInstance(cat_ids, dict)
+        self.assertDictEqual(cat_ids, dict(gender=[0], wear=[0, 2]))
+
+    def test_class_to_idx(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+        dataset = dataset_class(**self.DEFAULT_ARGS)
+
+        self.assertDictEqual(
+            dataset.class_to_idx,
+            dict(
+                gender={
+                    'male': 0,
+                    'female': 1
+                },
+                wear={
+                    'shirt': 0,
+                    'coat': 1,
+                    'jeans': 2,
+                    'pants': 3
+                }))
+
+    def test_evaluate(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+        dataset = dataset_class(**self.DEFAULT_ARGS)
+
+        fake_results = [
+            dict(gender=[0.7, 0.3], wear=[1, 0, 1, 0]),
+            dict(gender=[0.4, 0.6], wear=[1, 0, 1, 0]),
+            dict(gender=[0.1, 0.9], wear=[1, 0, 1, 0])
+        ]
+
+        eval_results = dataset.evaluate(
+            fake_results,
+            metric=dict(
+                gender=[
+                    'precision', 'recall', 'f1_score', 'support', 'accuracy'
+                ],
+                wear=['mAP', 'CR', 'OF1']),
+            metric_options=dict(gender={'topk': 1}))
+
+        # Test results
+        self.assertAlmostEqual(
+            eval_results['gender_precision'], (1 / 2 + 1) / 2 * 100.0,
+            places=4)
+        self.assertAlmostEqual(
+            eval_results['gender_recall'], (1 + 1 / 2) / 2 * 100.0, places=4)
+        self.assertAlmostEqual(
+            eval_results['gender_f1_score'], (2 / 3 + 2 / 3) / 2 * 100.0,
+            places=4)
+        self.assertEqual(eval_results['gender_support'], 3)
+        self.assertAlmostEqual(
+            eval_results['gender_accuracy'], 2 / 3 * 100, places=4)
+        self.assertAlmostEqual(eval_results['wear_mAP'], 66.67, places=2)
+        self.assertAlmostEqual(eval_results['wear_CR'], 50, places=2)
+        self.assertAlmostEqual(eval_results['wear_OF1'], 66.67, places=2)
+
+        # test indices
+        eval_results = dataset.evaluate(
+            fake_results[:2],
+            metric=dict(
+                gender=[
+                    'precision', 'recall', 'f1_score', 'support', 'accuracy'
+                ],
+                wear=['mAP', 'CR', 'OF1']),
+            metric_options=dict(gender={'topk': 1}),
+            indices=range(2))
+        self.assertAlmostEqual(
+            eval_results['gender_precision'], (1 + 0) / 2 * 100.0, places=4)
+        self.assertAlmostEqual(
+            eval_results['gender_recall'], (1 / 2 + 0) / 2 * 100.0, places=4)
+        self.assertAlmostEqual(
+            eval_results['gender_f1_score'], (2 / 3 + 0) / 2 * 100.0, places=4)
+        self.assertEqual(eval_results['gender_support'], 2)
+        self.assertAlmostEqual(
+            eval_results['gender_accuracy'], 1 / 2 * 100, places=4)
+
+        self.assertAlmostEqual(eval_results['wear_mAP'], 50, places=2)
+        self.assertAlmostEqual(eval_results['wear_CR'], 50, places=2)
+        self.assertAlmostEqual(eval_results['wear_OF1'], 100, places=2)
+
+    def test_repr(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+        dataset = dataset_class(**self.DEFAULT_ARGS)
+
+        task_doc = ('    For 2 tasks\n'
+                    '        gender (2 categories, single-label)\n'
+                    '        wear (4 categories, multi-label)')
+        self.assertIn(task_doc, repr(dataset))

--- a/tests/test_data/test_pipelines/test_formatting.py
+++ b/tests/test_data/test_pipelines/test_formatting.py
@@ -1,0 +1,37 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from copy import deepcopy
+from unittest import TestCase
+
+import torch
+
+from mmcls.datasets import PIPELINES
+
+
+class TestFormatMultiTaskLabels(TestCase):
+
+    def test_call(self):
+        results = {
+            'task1_img_label': 1,
+            'task2_img_label': [0, 1, 0, 1],
+        }
+        cfg = dict(type='FormatMultiTaskLabels', tasks=['task1', 'task2'])
+
+        transform = PIPELINES.build(cfg)
+        results_ = transform(deepcopy(results))
+        self.assertIn('gt_label', results_)
+        self.assertIsInstance(results_['gt_label']['task1'], torch.LongTensor)
+        self.assertIsInstance(results_['gt_label']['task2'], torch.Tensor)
+
+        # test auto parse task
+        cfg = dict(type='FormatMultiTaskLabels')
+        transform = PIPELINES.build(cfg)
+        results_ = transform(deepcopy(results))
+        self.assertIsInstance(results_['gt_label']['task1'], torch.LongTensor)
+        self.assertIsInstance(results_['gt_label']['task2'], torch.Tensor)
+
+    def test_repr(self):
+        cfg = dict(type='FormatMultiTaskLabels', tasks=['task1', 'task2'])
+
+        transform = PIPELINES.build(cfg)
+        self.assertEquals(
+            repr(transform), "FormatMultiTaskLabels(tasks=['task1', 'task2'])")


### PR DESCRIPTION
## Motivation

To support using a single backbone to perform multiple classification tasks.

## Modification

This PR is one part of the multi-task support plan, and it depends on #675 to build a network.

## BC-breaking (Optional)

No

## Use cases

Here is a detailed multi-task support design. First, the *multi-task* means using one backbone and multiple heads to do classification on an image with multiple kinds of labels.

### Dataset

The *current* multi-task requires full labels on every image, which means you cannot use partial-labeled samples to train the multi-task model.

To create a multi-task dataset, you can use the `MultiTaskDataset` class and prepare an annotation file. Here is a brief example:
#### *The annotation json file example*
```json
{
  "metainfo": {
    "tasks":
      [
        {"name": "gender",
         "type": "single-label",
         "categories": ["male", "female"]},
        {"name": "wear",
         "type": "multi-label",
         "categories": ["shirt", "coat", "jeans", "pants"]}
      ]
  },
  "data_list": [
    {
      "img_path": "a.jpg",
      "gender_img_label": 0,
      "wear_img_label": [1, 0, 1, 0]
    },
    {
      "img_path": "b.jpg",
      "gender_img_label": 1,
      "wear_img_label": [0, 1, 0, 1]
    },
    ...
  ]
}
```
The detailed usage and example of the `MultiTaskDataset` can be found [here](https://mmcls-test.readthedocs.io/en/multi-task/api/datasets.html#multi-task-dataset)

And here is a [script](https://gist.github.com/mzr1996/4e81a4c0e59fb140ffe0d17ff4f352ed) to use the CIFAR10 dataset to generate an example multi-task dataset, just run it in the `data` folder. And here is the file structure.
```
data/
├── cifar10
│   ├── images
│   ├── multi-task-test.json
│   └── multi-task-train.json
```

And here is an example config to train on the multi-task dataset.

```python
# Save as `configs/resnet/multi-task-demo.py`
_base_ = ['../_base_/schedules/cifar10_bs128.py', '../_base_/default_runtime.py']

# model settings
model = dict(
    type='ImageClassifier',
    backbone=dict(type='ResNet_CIFAR', depth=18),
    neck=dict(type='GlobalAveragePooling'),
    head=dict(
        type='MultiTaskClsHead',                                    # <- Head config, depends on #675
        sub_heads={
            'task1': dict(type='LinearClsHead', num_classes=6),
            'task2': dict(type='LinearClsHead', num_classes=6),
        },
        common_cfg=dict(
            in_channels=512,
            loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
        ),
    ),
)

# dataset settings
dataset_type = 'MultiTaskDataset'
img_norm_cfg = dict(
    mean=[125.307, 122.961, 113.8575],
    std=[51.5865, 50.847, 51.255],
    to_rgb=False)
train_pipeline = [
    dict(type='LoadImageFromFile'),
    dict(type='RandomCrop', size=32, padding=4),
    dict(type='RandomFlip', flip_prob=0.5, direction='horizontal'),
    dict(type='Normalize', **img_norm_cfg),
    dict(type='ImageToTensor', keys=['img']),
    dict(type='FormatMultiTaskLabels'),                             # <- Use this to replace `ToTensor`.
    dict(type='Collect', keys=['img', 'gt_label'])
]
test_pipeline = [
    dict(type='LoadImageFromFile'),
    dict(type='Normalize', **img_norm_cfg),
    dict(type='ImageToTensor', keys=['img']),
    dict(type='Collect', keys=['img'])
]
data = dict(
    samples_per_gpu=16,
    workers_per_gpu=2,
    train=dict(
        type=dataset_type,
        data_root='data/cifar10',
        ann_file='multi-task-train.json',
        pipeline=train_pipeline),
    val=dict(
        type=dataset_type,
        data_root='data/cifar10',
        ann_file='multi-task-test.json',
        pipeline=test_pipeline,
        test_mode=True),
    test=dict(
        type=dataset_type,
        data_root='data/cifar10',
        ann_file='multi-task-test.json',
        pipeline=test_pipeline,
        test_mode=True))

evaluation = dict(metric_options={
    'task1': dict(topk=(1, )),                # <- Specify different metric options for different tasks.
    'task2': dict(topk=(1, 3)),
})
```

Then, we can train the dataset by `python tools/train.py configs/resnet/multi-task-demo.py`

```
2022-04-29 18:25:37,968 - mmcls - INFO - workflow: [('train', 1)], max: 200 epochs
2022-04-29 18:25:37,968 - mmcls - INFO - Checkpoints will be saved to /home/work_dirs/multi-task-demo by HardDiskBackend.
2022-04-29 18:25:42,280 - mmcls - INFO - Epoch [1][100/2813]    lr: 1.000e-01, eta: 6:43:27, time: 0.043, data_time: 0.021, memory: 329, task1_loss: 1.7489, task2_loss: 1.6522, loss: 3.4011
...
2022-04-29 18:26:24,813 - mmcls - INFO - Saving checkpoint at 1 epochs
2022-04-29 18:26:26,951 - mmcls - INFO - Epoch(val) [1][313]    task1_accuracy_top-1: 62.7000, task2_accuracy_top-1: 65.6800, task2_accuracy_top-3: 96.4800
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
