### PR TITLE
potential bug for vision transformer classification head

### DIFF
--- a/mmcls/models/heads/vision_transformer_head.py
+++ b/mmcls/models/heads/vision_transformer_head.py
@@ -24,8 +24,7 @@ class VisionTransformerClsHead(ClsHead):
             Defaults to None, which means no extra hidden layer.
         act_cfg (dict): The activation config. Only available during
             pre-training. Defaults to ``dict(type='Tanh')``.
-        init_cfg (dict): The extra initialization configs. Defaults to
-            ``dict(type='Constant', layer='Linear', val=0)``.
+        init_cfg (dict): The extra initialization configs.
     """
 
     def __init__(self,
@@ -33,7 +32,7 @@ class VisionTransformerClsHead(ClsHead):
                  in_channels,
                  hidden_dim=None,
                  act_cfg=dict(type='Tanh'),
-                 init_cfg=dict(type='Constant', layer='Linear', val=0),
+                 init_cfg=None,
                  *args,
                  **kwargs):
         super(VisionTransformerClsHead, self).__init__(


### PR DESCRIPTION
## Motivation

The Linear Layer is usually initialized by truncnormal init method in Vision Transformers, and is defined in the main model. The current implementation, if not carefully checked, may lead to a zero initialization on the head. I know the original JAX implementation of ViT uses such a zero initialization, but many other Vision Transoformers implemented with torch usually use a truncnormal init, which may not carefully considred in the config files in this repo (e.g. [DeiT](https://github.com/open-mmlab/mmclassification/blob/7c5ddb1e5bee68d52ff8b5622cdbd75c02792c07/configs/deit/deit-small_pt-4xb256_in1k.py#L18)).


## Modification

change default init_cfg to None of Vision Transformer cls head.


## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
