### PR TITLE
[fix] val loader should not drop last by default.

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -222,6 +222,7 @@ def train_model(model,
             **loader_cfg,
             'shuffle': False,  # Not shuffle by default
             'sampler_cfg': None,  # Not use sampler by default
+            'drop_last': False,  # Not drop last by default
             **cfg.data.get('val_dataloader', {}),
         }
         val_dataloader = build_dataloader(val_dataset, **val_loader_cfg)


### PR DESCRIPTION
## Motivation

Val loader should not drop last by default.

## Modification

add 'drop_last': False in val_loader_cfg by default.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
