### PR TITLE
[Fix] Fix warning with `torch.meshgrid`.

### DIFF
--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -12,7 +12,8 @@ def get_relative_position_index(window_size):
     """Method from original code of Swin-Transformer."""
     coords_h = torch.arange(window_size[0])
     coords_w = torch.arange(window_size[1])
-    coords = torch.stack(torch.meshgrid([coords_h, coords_w]))  # 2, Wh, Ww
+    coords = torch.stack(torch.meshgrid([coords_h, coords_w],
+                                        indexing='ij'))  # 2, Wh, Ww
     coords_flatten = torch.flatten(coords, 1)  # 2, Wh*Ww
     # 2, Wh*Ww, Wh*Ww
     relative_coords = coords_flatten[:, :, None] - coords_flatten[:, None, :]

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -6,14 +6,14 @@ import pytest
 import torch
 
 from mmcls.models.utils.attention import ShiftWindowMSA, WindowMSA
+from .test_misc import torch_meshgrid_ij
 
 
 def get_relative_position_index(window_size):
     """Method from original code of Swin-Transformer."""
     coords_h = torch.arange(window_size[0])
     coords_w = torch.arange(window_size[1])
-    coords = torch.stack(torch.meshgrid([coords_h, coords_w],
-                                        indexing='ij'))  # 2, Wh, Ww
+    coords = torch.stack(torch_meshgrid_ij([coords_h, coords_w]))  # 2, Wh, Ww
     coords_flatten = torch.flatten(coords, 1)  # 2, Wh*Ww
     # 2, Wh*Ww, Wh*Ww
     relative_coords = coords_flatten[:, :, None] - coords_flatten[:, None, :]

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -1,12 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from functools import partial
 from unittest import TestCase
 from unittest.mock import ANY, MagicMock
 
 import pytest
 import torch
+from mmcv.utils import TORCH_VERSION, digit_version
 
 from mmcls.models.utils.attention import ShiftWindowMSA, WindowMSA
-from .test_misc import torch_meshgrid_ij
+
+if digit_version(TORCH_VERSION) >= digit_version('1.10.0a0'):
+    torch_meshgrid_ij = partial(torch.meshgrid, indexing='ij')
+else:
+    torch_meshgrid_ij = torch.meshgrid  # Uses indexing='ij' by default
 
 
 def get_relative_position_index(window_size):

--- a/tests/test_models/test_utils/test_misc.py
+++ b/tests/test_models/test_utils/test_misc.py
@@ -2,7 +2,6 @@
 import pytest
 import torch
 from mmcv.utils import digit_version
-from packaging import version
 
 from mmcls.models.utils import channel_shuffle, is_tracing, make_divisible
 
@@ -58,14 +57,3 @@ def test_is_tracing():
     # test with trace
     traced_foo = torch.jit.trace(foo, (torch.rand(1), ))
     assert isinstance(traced_foo(x), torch.Tensor)
-
-
-_torch_version_meshgrid_indexing = version.parse(
-    torch.__version__) >= version.parse('1.10.0a0')
-
-
-def torch_meshgrid_ij(*tensors):
-    if _torch_version_meshgrid_indexing:
-        return torch.meshgrid(*tensors, indexing='ij')
-    else:
-        return torch.meshgrid(*tensors)  # Uses indexing='ij' by default

--- a/tests/test_models/test_utils/test_misc.py
+++ b/tests/test_models/test_utils/test_misc.py
@@ -2,6 +2,7 @@
 import pytest
 import torch
 from mmcv.utils import digit_version
+from packaging import version
 
 from mmcls.models.utils import channel_shuffle, is_tracing, make_divisible
 
@@ -57,3 +58,14 @@ def test_is_tracing():
     # test with trace
     traced_foo = torch.jit.trace(foo, (torch.rand(1), ))
     assert isinstance(traced_foo(x), torch.Tensor)
+
+
+_torch_version_meshgrid_indexing = version.parse(
+    torch.__version__) >= version.parse('1.10.0a0')
+
+
+def torch_meshgrid_ij(*tensors):
+    if _torch_version_meshgrid_indexing:
+        return torch.meshgrid(*tensors, indexing='ij')
+    else:
+        return torch.meshgrid(*tensors)  # Uses indexing='ij' by default


### PR DESCRIPTION
## Motivation

`torch.meshgrid()` has started raising a warning when not called with an explicit indexing parameter:
https://pytorch.org/docs/stable/generated/torch.meshgrid.html

## Modification

Provide `indexing='ij'` to all calls to `torch.meshgrid` that don't already specify indexing.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
