### PR TITLE
[DOC BUG] Fix doc about pretrain model setting 

### DIFF
--- a/docs/en/tutorials/finetune.md
+++ b/docs/en/tutorials/finetune.md
@@ -57,11 +57,12 @@ datasets by just changing `num_classes` in the head.
 ```python
 model = dict(
     backbone=dict(
-        init_cfg=dict(
-            type='Pretrained',
-            checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
-            prefix='backbone',
-        )),
+        init_cfg=[
+            dict(
+                type='Pretrained',
+                checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
+                prefix='backbone')
+        ]),
     head=dict(num_classes=10),
 )
 ```
@@ -81,11 +82,12 @@ freeze the first two layers' parameters, just use the following config:
 model = dict(
     backbone=dict(
         frozen_stages=2,
-        init_cfg=dict(
-            type='Pretrained',
-            checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
-            prefix='backbone',
-        )),
+        init_cfg=[
+            dict(
+                type='Pretrained',
+                checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
+                prefix='backbone')
+        ]),
     head=dict(num_classes=10),
 )
 ```

--- a/docs/zh_CN/tutorials/finetune.md
+++ b/docs/zh_CN/tutorials/finetune.md
@@ -50,11 +50,12 @@ _base_ = [
 ```python
 model = dict(
     backbone=dict(
-        init_cfg=dict(
-            type='Pretrained',
-            checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
-            prefix='backbone',
-        )),
+        init_cfg=[
+            dict(
+                type='Pretrained',
+                checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
+                prefix='backbone')
+        ]),
     head=dict(num_classes=10),
 )
 ```
@@ -72,11 +73,12 @@ model = dict(
 model = dict(
     backbone=dict(
         frozen_stages=2,
-        init_cfg=dict(
-            type='Pretrained',
-            checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
-            prefix='backbone',
-        )),
+        init_cfg=[
+            dict(
+                type='Pretrained',
+                checkpoint='https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth',
+                prefix='backbone')
+        ]),
     head=dict(num_classes=10),
 )
 ```


### PR DESCRIPTION
## Motivation

I follow the doc to set the pretrain  model will get this error
```bash
TypeError: init_cfg={'type': 'Pretrained', 'checkpoint': 'https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth', 'prefix': 'backbone'} in child config cannot inherit from base because init_cfg is a dict in the child config but is of type <class 'list'> in base config. You may set `_delete_=True` to ignore the base config.

```

## Modification

Fix the doc about pretrain model setting

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
