### PR TITLE
[Fix] Add matplotlib minimum version requriments.

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,3 +1,3 @@
-matplotlib
+matplotlib>=3.1.0
 numpy
 packaging


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

fix `show_result` error.

`fig.add_subplot() == None` when `matplotlib==3.0.3`, here is my callstack:

```bash
> /home/PJLAB/konghuanjun/GitProjects/mmclassification/mmcls/core/visualization/image.py(68)_initialize_fig_save()
-> ax = fig.add_subplot()
(Pdb) p fig
<Figure size 230.4x172.8 with 0 Axes>
(Pdb) n
> /home/PJLAB/konghuanjun/GitProjects/mmclassification/mmcls/core/visualization/image.py(71)_initialize_fig_save()
-> fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
(Pdb) p ax
None
...
(Pdb) matplotlib.__version__
'3.0.3'
```

> "In matplotlib < 3.1 you will need to explicitly state the position of the subplot in the grid"
https://stackoverflow.com/questions/56632987/matplotlib-figure-figure-add-subplots-and-add-axes-return-none-instead-of-ax

## Modification

update `requirements.txt`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
