### PR TITLE
[Fix Serious BUG] Using Albu will crash the trainning

### DIFF
--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1122,10 +1122,9 @@ class Albu(object):
 
         results = self.aug(**results)
 
-        if 'gt_labels' in results:
-            if isinstance(results['gt_labels'], list):
-                results['gt_labels'] = np.array(results['gt_labels'])
-            results['gt_labels'] = results['gt_labels'].astype(np.int64)
+        if 'gt_label' in results and results['gt_label'].shape != ():
+            # Albu will make the label from array(x) to array([x])
+            results['gt_label'] = np.array(results['gt_label'][0]).astype(np.int64)
 
         # back to the original format
         results = self.mapper(results, self.keymap_back)

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1132,12 +1132,12 @@ class Albu(object):
         # process aug
         results = self.aug(**results)
 
-        # back to the original format
-        results = self.mapper(results, self.keymap_back)
-
         if _gt_label is not None:
             # update the original gt_label
             results.update({'gt_label': _gt_label})
+
+        # back to the original format
+        results = self.mapper(results, self.keymap_back)
 
         # update final shape
         if self.update_pad_shape:

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1118,26 +1118,22 @@ class Albu(object):
         return updated_dict
 
     def __call__(self, results):
+
+        # backup gt_label incase Albu modify it.
+        _gt_label = copy.deepcopy(results.get('gt_label', None))
+
         # dict to albumentations format
         results = self.mapper(results, self.keymap_to_albu)
-
-        if 'gt_label' in results:
-            if isinstance(results['gt_label'], list):
-                results['gt_label'] = np.array(results['gt_label'])
-            results['gt_label'] = results['gt_label'].astype(np.int64)
-
-        # save gt_label incase Albu modify it.
-        _gt_label = copy.deepcopy(results.get('gt_label', None))
 
         # process aug
         results = self.aug(**results)
 
-        if _gt_label is not None:
-            # update the original gt_label
-            results.update({'gt_label': _gt_label})
-
         # back to the original format
         results = self.mapper(results, self.keymap_back)
+
+        if _gt_label is not None:
+            # recover backup gt_label
+            results.update({'gt_label': _gt_label})
 
         # update final shape
         if self.update_pad_shape:

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1119,7 +1119,7 @@ class Albu(object):
 
     def __call__(self, results):
 
-        # backup gt_label incase Albu modify it.
+        # backup gt_label in case Albu modify it.
         _gt_label = copy.deepcopy(results.get('gt_label', None))
 
         # dict to albumentations format

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1123,7 +1123,7 @@ class Albu(object):
         results = self.aug(**results)
 
         if 'gt_label' in results and results['gt_label'].shape != ():
-            # Albu will make the label from array(x) to array([x])
+            # Albu will change the label from array(x) to array([x])
             results['gt_label'] = np.array(results['gt_label'][0]).astype(np.int64)
 
         # back to the original format

--- a/tests/test_data/test_pipelines/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform.py
@@ -1269,8 +1269,7 @@ def test_albu_transform():
     results = dict(
         img_prefix=osp.join(osp.dirname(__file__), '../../data'),
         img_info=dict(filename='color.jpg'),
-        gt_label=np.array(1)
-    )
+        gt_label=np.array(1))
 
     # Define simple pipeline
     load = dict(type='LoadImageFromFile')
@@ -1287,8 +1286,7 @@ def test_albu_transform():
                 rotate_limit=0,
                 interpolation=1,
                 p=1)
-        ]
-    )
+        ])
     albu_transform = build_from_cfg(albu_transform, PIPELINES)
 
     normalize = dict(type='Normalize', mean=[0] * 3, std=[0] * 3, to_rgb=True)

--- a/tests/test_data/test_pipelines/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform.py
@@ -1268,14 +1268,27 @@ def test_lighting():
 def test_albu_transform():
     results = dict(
         img_prefix=osp.join(osp.dirname(__file__), '../../data'),
-        img_info=dict(filename='color.jpg'))
+        img_info=dict(filename='color.jpg'),
+        gt_label=np.array(1)
+    )
 
     # Define simple pipeline
     load = dict(type='LoadImageFromFile')
     load = build_from_cfg(load, PIPELINES)
 
     albu_transform = dict(
-        type='Albu', transforms=[dict(type='ChannelShuffle', p=1)])
+        type='Albu',
+        transforms=[
+            dict(type='ChannelShuffle', p=1),
+            dict(
+                type='ShiftScaleRotate',
+                shift_limit=0.0625,
+                scale_limit=0.0,
+                rotate_limit=0,
+                interpolation=1,
+                p=1)
+        ]
+    )
     albu_transform = build_from_cfg(albu_transform, PIPELINES)
 
     normalize = dict(type='Normalize', mean=[0] * 3, std=[0] * 3, to_rgb=True)
@@ -1287,3 +1300,4 @@ def test_albu_transform():
     results = normalize(results)
 
     assert results['img'].dtype == np.float32
+    assert results['gt_label'].shape == np.array(1).shape


### PR DESCRIPTION
## Motivation

When I use Albu for dataset aug, It cause error :
![c2efab7c719a40a3720e18396738935](https://user-images.githubusercontent.com/25873202/179757175-f31c643c-f9e5-4ba5-9899-cb35543858af.jpg)

## Modification

I debug and found out that becuase the Albu will change the label from `array(x)` to `array([x])`, which will crash the trainning.

And I also find out that there are no field `gt_labels` in all configs file in mmcls. So I think is inherit from mmdet.

Becuase of that I correct it in mmcls with `gt_label` and added some code to change it back to `array(x)` after albu change it to incorrect type `array([x])`

Thx for @Ezra-Yu ,we can find it in here: 

https://github.com/albumentations-team/albumentations/blob/a8dc46ee29f9573c8569213f0d243254980b02f1/albumentations/core/composition.py#L276-L282

![image](https://user-images.githubusercontent.com/25873202/181024802-f6c154ff-7bef-402a-8496-108c2b740d77.png)


## Note
If need to test this PR before mmcls merge into master branch, we need to **reinstall mmcls after modefied this file**.
```shell
pip uninstall mmcls -y && pip install -e .
```

## Config
```python
train = dict(
    type='ImageNet',
    pipeline=[
        dict(type='LoadImageFromFile'),
        dict(
            type='Albu',
            transforms=[
                dict(
                    type='ShiftScaleRotate',
                    shift_limit=0.0625,
                    scale_limit=0.0,
                    rotate_limit=0,
                    interpolation=1,
                    p=0.5),
                dict(
                    type='RandomBrightnessContrast',
                    brightness_limit=[0.1, 0.3],
                    contrast_limit=[0.1, 0.3],
                    p=0.2),
                dict(type='ChannelShuffle', p=0.1),
                dict(
                    type='OneOf',
                    transforms=[
                        dict(type='Blur', blur_limit=3, p=1.0),
                        dict(type='MedianBlur', blur_limit=3, p=1.0)
                    ],
                    p=0.1),
            ]),
            dict(type='ImageToTensor', keys=['img']),
            dict(type='ToTensor', keys=['gt_label']),
            dict(type='Collect', keys=['img', 'gt_label'])
    ]
),
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
