### PR TITLE
add arcface

### DIFF
--- a/mmcls/models/heads/__init__.py
+++ b/mmcls/models/heads/__init__.py
@@ -5,11 +5,12 @@ from .deit_head import DeiTClsHead
 from .linear_head import LinearClsHead
 from .multi_label_cls_head import MultiLabelClsHead
 from .multi_label_linear_head import MultiLabelLinearClsHead
+from .norm_linear_head import NormLinearClsHead
 from .stacked_head import StackedLinearClsHead
 from .vision_transformer_head import VisionTransformerClsHead
 
 __all__ = [
     'ClsHead', 'LinearClsHead', 'StackedLinearClsHead', 'MultiLabelClsHead',
     'MultiLabelLinearClsHead', 'VisionTransformerClsHead', 'DeiTClsHead',
-    'ConformerHead'
+    'ConformerHead', 'NormLinearClsHead'
 ]

--- a/mmcls/models/heads/norm_linear_head.py
+++ b/mmcls/models/heads/norm_linear_head.py
@@ -1,0 +1,87 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from mmcls.data import ClsDataSample
+from mmcls.models.heads import ClsHead
+from mmcls.registry import MODELS
+
+
+class NormLinear(nn.Linear):
+
+    def __init__(self, in_features: int, out_features: int, bias: bool,
+                 feature_norm: bool, weight_norm: bool):
+        super().__init__(in_features, out_features, bias=bias)
+        self.weight_norm = weight_norm
+        self.feature_norm = feature_norm
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.feature_norm:
+            input = F.normalize(input)
+        if self.weight_norm:
+            weight = F.normalize(self.weight)
+        else:
+            weight = self.weight
+        return F.linear(input, weight, self.bias)
+
+
+@MODELS.register_module()
+class NormLinearClsHead(ClsHead):
+
+    def __init__(self,
+                 num_classes: int,
+                 in_channels: int,
+                 feature_norm: bool,
+                 weight_norm: bool,
+                 bias: bool,
+                 init_cfg: Optional[dict] = dict(
+                     type='Normal', layer='Linear', std=0.01),
+                 *args,
+                 **kwargs):
+        super(NormLinearClsHead, self).__init__(
+            init_cfg=init_cfg, *args, **kwargs)
+
+        assert hasattr('s', self.compute_loss),\
+            'NormLinearClsHead.compute_loss should have `s` like ArcFaceLoss.'
+
+        self.in_channels = in_channels
+        self.num_classes = num_classes
+
+        if self.num_classes <= 0:
+            raise ValueError(
+                f'num_classes={num_classes} must be a positive integer')
+
+        self.fc = NormLinear(self.in_channels, self.num_classes, bias,
+                             feature_norm, weight_norm)
+
+    def pre_logits(self, feats: Tuple[torch.Tensor]) -> torch.Tensor:
+        """The process before the final classification head.
+
+        The input ``feats`` is a tuple of tensor, and each tensor is the
+        feature of a backbone stage. In ``LinearClsHead``, we just obtain the
+        feature of the last stage.
+        """
+        # The NormLinearClsHead doesn't have other module, just return after
+        # unpacking.
+        return feats[-1]
+
+    def forward(self, feats: Tuple[torch.Tensor]) -> torch.Tensor:
+        pre_logits = self.pre_logits(feats)
+        cls_score = self.fc(pre_logits)
+        return cls_score
+
+    def predict(
+            self,
+            feats: Tuple[torch.Tensor],
+            data_samples: List[ClsDataSample] = None) -> List[ClsDataSample]:
+        """Test without augmentation."""
+        # The part can be traced by torch.fx
+        cls_score = self(feats)
+        cls_score = cls_score * self.compute_loss.s
+
+        # The part can not be traced by torch.fx
+        predictions = self._get_predictions(cls_score, data_samples)
+        return predictions

--- a/mmcls/models/losses/__init__.py
+++ b/mmcls/models/losses/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from .arcface_loss import ArcFaceLoss
 from .asymmetric_loss import AsymmetricLoss, asymmetric_loss
 from .cross_entropy_loss import (CrossEntropyLoss, binary_cross_entropy,
                                  cross_entropy)
@@ -12,5 +13,5 @@ __all__ = [
     'asymmetric_loss', 'AsymmetricLoss', 'cross_entropy',
     'binary_cross_entropy', 'CrossEntropyLoss', 'reduce_loss',
     'weight_reduce_loss', 'LabelSmoothLoss', 'weighted_loss', 'FocalLoss',
-    'sigmoid_focal_loss', 'convert_to_one_hot', 'SeesawLoss'
+    'sigmoid_focal_loss', 'convert_to_one_hot', 'SeesawLoss', 'ArcFaceLoss'
 ]

--- a/mmcls/models/losses/arcface_loss.py
+++ b/mmcls/models/losses/arcface_loss.py
@@ -1,0 +1,68 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import math
+
+import torch
+from mmcv.runner import force_fp32
+from torch import nn
+from torch.nn import functional as F
+
+from mmcls.models.losses.cross_entropy_loss import soft_cross_entropy
+from mmcls.registry import MODELS
+
+
+@MODELS.register_module()
+class ArcFaceLoss(nn.Module):
+
+    def __init__(self,
+                 s: float = 30.0,
+                 m: float = 0.5,
+                 reduction='mean',
+                 loss_weight: float = 1.0,
+                 class_weight=None):
+        super().__init__()
+        self.s = s
+        self.m = m
+        self.mm = math.sin(math.pi - m) * m
+        self.threshold = math.cos(math.pi - m)  # (t + m) == pi
+
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+        self.class_weight = class_weight
+        self.fp16_enabled = False
+
+    @force_fp32(apply_to=('input', ))
+    def forward(self,
+                input,
+                target,
+                weight=None,
+                avg_factor=None,
+                reduction_override=None):
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
+
+        with torch.cuda.amp.autocast(enabled=False):
+            if self.class_weight is not None:
+                class_weight = input.new_tensor(self.class_weight)
+            else:
+                class_weight = None
+
+            with torch.no_grad():
+                ont_hot_target = F.one_hot(target, num_classes=input.size(-1))
+
+            cos_t = input.clamp(-1, 1)
+            cos_t_m = torch.cos(torch.acos(cos_t) + self.m)
+            cos_t_m = torch.where(cos_t > self.threshold, cos_t_m,
+                                  cos_t - self.mm)
+
+            logit = ont_hot_target * cos_t_m + (1 - ont_hot_target) * cos_t
+            logit = logit * self.s
+
+            loss = soft_cross_entropy(
+                logit,
+                ont_hot_target,
+                weight=weight,
+                reduction=reduction,
+                class_weight=class_weight,
+                avg_factor=avg_factor)
+        return self.loss_weight * loss

--- a/tests/test_models/test_heads.py
+++ b/tests/test_models/test_heads.py
@@ -437,3 +437,53 @@ class TestMultiLabelLinearClsHead(TestMultiLabelClsHead):
         # return the last item (same as pre_logits)
         feats = (torch.rand(4, 10), torch.rand(4, 10))
         head(feats)
+
+
+class TestNormLinearClsHead(TestCase):
+    DEFAULT_ARGS = dict(
+        type='NormLinearClsHead',
+        in_channels=10,
+        num_classes=5,
+        feature_norm=True,
+        weight_norm=True,
+        bias=False,
+        loss=dict(type='ArcFaceLoss'))
+
+    def test_initialize(self):
+        with self.assertRaisesRegex(ValueError, 'num_classes=-5 must be'):
+            MODELS.build({**self.DEFAULT_ARGS, 'num_classes': -5})
+
+    def test_pre_logits(self):
+        head = MODELS.build(self.DEFAULT_ARGS)
+
+        # return the last item
+        feats = (torch.rand(4, 10), torch.rand(4, 10))
+        pre_logits = head.pre_logits(feats)
+        self.assertIs(pre_logits, feats[-1])
+
+    def test_forward(self):
+        head = MODELS.build(self.DEFAULT_ARGS)
+
+        feats = (torch.rand(4, 10), torch.rand(4, 10))
+        outs = head(feats)
+        self.assertEqual(outs.shape, (4, 5))
+
+    def test_predict(self):
+        feats = (torch.rand(4, 10), )
+        data_samples = [ClsDataSample().set_gt_label(1) for _ in range(4)]
+        head = MODELS.build(self.DEFAULT_ARGS)
+
+        # with without data_samples
+        predictions = head.predict(feats)
+        self.assertTrue(is_seq_of(predictions, ClsDataSample))
+        for pred in predictions:
+            self.assertIn('label', pred.pred_label)
+            self.assertIn('score', pred.pred_label)
+
+        # with with data_samples
+        predictions = head.predict(feats, data_samples)
+        self.assertTrue(is_seq_of(predictions, ClsDataSample))
+        for sample, pred in zip(data_samples, predictions):
+            self.assertIs(sample, pred)
+            self.assertIn('label', pred.pred_label)
+            self.assertIn('score', pred.pred_label)

--- a/tests/test_models/test_losses.py
+++ b/tests/test_models/test_losses.py
@@ -360,3 +360,31 @@ def test_seesaw_loss():
     fake_label = torch.Tensor([0]).long()
     loss = loss_cls(fake_pred, fake_label)
     assert torch.allclose(loss, torch.tensor(200.) + torch.tensor(100.).log())
+
+
+def test_arcface_loss():
+    # test arcface_loss
+    cls_score = torch.Tensor([[0.5, 0.7], [0.7, 0.1]])
+    label = torch.Tensor([0, 1]).long()
+    class_weight = [0.3, 0.7]  # class 0 : 0.3, class 1 : 0.7
+    weight = torch.tensor([0.6, 0.4])
+
+    # test arcface_loss without class weight
+    loss_cfg = dict(type='ArcFaceLoss', reduction='mean', loss_weight=1.0)
+    loss = build_loss(loss_cfg)
+    assert torch.allclose(loss(cls_score, label), torch.tensor(26.4850))
+    # test arcface_loss with weight
+    assert torch.allclose(
+        loss(cls_score, label, weight=weight), torch.tensor(12.6232))
+
+    # test arcface_loss with class weight
+    loss_cfg = dict(
+        type='ArcFaceLoss',
+        reduction='mean',
+        loss_weight=1.0,
+        class_weight=class_weight)
+    loss = build_loss(loss_cfg)
+    assert torch.allclose(loss(cls_score, label), torch.tensor(14.4811))
+    # test ce_loss with weight
+    assert torch.allclose(
+        loss(cls_score, label, weight=weight), torch.tensor(6.4012))


### PR DESCRIPTION
## Motivation

Other implementation of arcface. I suggest this style.
Related to https://github.com/open-mmlab/mmclassification/pull/926 .

mmengine hasn't released yet, so I haven't checked tests pass.

## Use cases (Optional)

I used this implement at [kaggle happy whale competition](https://www.kaggle.com/competitions/happy-whale-and-dolphin) .

```
head=dict(
                 type='NormLinearClsHead',
                 num_classes=15587,
                 in_channels=5504,
                 feature_norm=True,
                 weight_norm=True,
                 bias=False,
                 loss=dict(type='ArcFaceLoss'),
                 topk=(1, 5),
                 cal_acc=True
             )
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
