### PR TITLE
[Feature] MultiheadAttentionPooling

### DIFF
--- a/mmcls/models/necks/__init__.py
+++ b/mmcls/models/necks/__init__.py
@@ -2,5 +2,9 @@
 from .gap import GlobalAveragePooling
 from .gem import GeneralizedMeanPooling
 from .hr_fuse import HRFuseScales
+from .map import MultiheadAttentionPooling
 
-__all__ = ['GlobalAveragePooling', 'GeneralizedMeanPooling', 'HRFuseScales']
+__all__ = [
+    'GlobalAveragePooling', 'GeneralizedMeanPooling', 'HRFuseScales',
+    'MultiheadAttentionPooling'
+]

--- a/mmcls/models/necks/map.py
+++ b/mmcls/models/necks/map.py
@@ -5,7 +5,10 @@ from mmcv.cnn.bricks import ConvModule
 from mmcv.cnn.bricks.transformer import MultiheadAttention
 from mmcv.runner import BaseModule
 
+from ..builder import NECKS
 
+
+@NECKS.register_module()
 class MultiheadAttentionPooling(BaseModule):
     """MultiheadAttentionPooling.
 

--- a/mmcls/models/necks/map.py
+++ b/mmcls/models/necks/map.py
@@ -57,6 +57,7 @@ class MultiheadAttentionPooling(BaseModule):
                     bias=False,
                 ),
                 nn.AdaptiveAvgPool2d(1),
+                nn.Flatten(),
             )
             final_layers.append(final_layer)
 
@@ -81,6 +82,6 @@ class MultiheadAttentionPooling(BaseModule):
             self.final_layers[i](feats[i])
             for i in range(len(self.in_channels))
         ]
-        feats = torch.stack(feats, dim=0).sum(dim=0)
 
+        feats = torch.stack(feats, dim=0).sum(dim=0)
         return (feats, )

--- a/mmcls/models/necks/map.py
+++ b/mmcls/models/necks/map.py
@@ -87,4 +87,4 @@ class MultiheadAttentionPooling(BaseModule):
         ]
 
         feats = torch.stack(feats, dim=0).sum(dim=0)
-        return (feats, )
+        return feats

--- a/mmcls/models/necks/map.py
+++ b/mmcls/models/necks/map.py
@@ -1,0 +1,86 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+import torch.nn as nn
+from mmcv.cnn.bricks import ConvModule
+from mmcv.cnn.bricks.transformer import MultiheadAttention
+from mmcv.runner import BaseModule
+
+
+class MultiheadAttentionPooling(BaseModule):
+    """MultiheadAttentionPooling.
+
+    Args:
+        in_channels (list[int]): The input channels of all scales.
+        num_heads (list[ing]): The number of heads of all pooling map.
+            Default to 8.
+        out_channels (int): The channels of used feature map.
+            Default to 2048.
+        init_cfg (dict | list[dict], optional): Initialization config dict.
+            Defaults to ``dict(type='Normal', layer='Linear', std=0.01))``.
+    """
+
+    def __init__(self,
+                 in_channels,
+                 num_heads,
+                 out_channels=2048,
+                 norm_cfg=dict(type='BN', momentum=0.1),
+                 init_cfg=dict(type='Normal', layer='Linear', std=0.01)):
+        super(MultiheadAttentionPooling, self).__init__(init_cfg=init_cfg)
+
+        self.in_channels = in_channels
+        self.num_heads = num_heads
+        self.norm_cfg = norm_cfg
+
+        assert len(self.in_channels) == len(
+            self.num_heads
+        ), 'The in_channels and num_heads must have the same length'
+
+        mhsa = list()
+        for i in range(len(in_channels)):
+            mhsa.append(
+                MultiheadAttention(
+                    embed_dims=in_channels[i],
+                    num_heads=num_heads[i],
+                    batch_first=True,
+                ), )
+
+        self.mhsa = nn.ModuleList(mhsa)
+
+        final_layers = list()
+        for i in range(len(in_channels)):
+            final_layer = nn.Sequential(
+                ConvModule(
+                    in_channels=in_channels[i],
+                    out_channels=out_channels,
+                    kernel_size=1,
+                    norm_cfg=self.norm_cfg,
+                    bias=False,
+                ),
+                nn.AdaptiveAvgPool2d(1),
+            )
+            final_layers.append(final_layer)
+
+        self.final_layers = nn.ModuleList(final_layers)
+
+    def mhsa_forward(self, x, model):
+        B, nc, h, w = x.shape
+        x = x.flatten(-2, -1).permute(0, 2, 1)
+        x = model(x)
+        x = x.permute(0, 2, 1)
+        x = x.view(B, nc, h, w)
+        return x.contiguous()
+
+    def forward(self, x):
+        assert isinstance(x, tuple) and len(x) == len(self.in_channels)
+
+        feats = [
+            self.mhsa_forward(x[i], self.mhsa[i])
+            for i in range(len(self.in_channels))
+        ]
+        feats = [
+            self.final_layers[i](feats[i])
+            for i in range(len(self.in_channels))
+        ]
+        feats = torch.stack(feats, dim=0).sum(dim=0)
+
+        return (feats, )

--- a/tests/test_models/test_neck.py
+++ b/tests/test_models/test_neck.py
@@ -105,6 +105,4 @@ def test_mhsa_check():
         neck(inputs)
 
     outs = neck(tuple(inputs))
-    assert isinstance(outs, tuple)
-    assert len(outs) == 1
-    assert outs[0].shape == (3, 1024, 7, 7)
+    assert outs.shape == (3, 1024)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR is adding feature of multi head attention pooling neck.
This feature is inspired by [Set Transformer: A Framework for Attention-based
Permutation-Invariant Neural Networks](http://proceedings.mlr.press/v97/lee19d/lee19d.pdf).

## Modification

The multi head attention pooling neck was implemented with maintaining the code style of the already existing [hr_fuse](https://github.com/open-mmlab/mmclassification/blob/master/mmcls/models/necks/hr_fuse.py).

## BC-breaking (Optional)

## Use cases (Optional)

The use cases of this feature is simply seen in test code.
However, surely the usage of this function is presented below.
```
in_channels = (18, 32, 64, 128)
neck = HRFuseScales(in_channels=in_channels, out_channels=1024)

feat_size = 56
inputs = []
for in_channel in in_channels:
    input_tensor = torch.rand(3, in_channel, feat_size, feat_size)
    inputs.append(input_tensor)
    feat_size = feat_size // 2

outs = neck(tuple(inputs))
assert isinstance(outs, tuple)
assert len(outs) == 1
assert outs[0].shape == (3, 1024, 7, 7)
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
