### PR TITLE
Dummy forward

### DIFF
--- a/mmcls/models/classifiers/image.py
+++ b/mmcls/models/classifiers/image.py
@@ -33,6 +33,13 @@ class ImageClassifier(BaseClassifier):
             if augments_cfg is not None:
                 self.augments = Augments(augments_cfg)
 
+    def forward_dummy(self, img):
+        """Used for computing network flops.
+
+        See `mmclassificaiton/tools/analysis_tools/get_flops.py`
+        """
+        return self.extract_feat(img, stage='pre_logits')
+
     def extract_feat(self, img, stage='neck'):
         """Directly extract features from the specified stage.
 

--- a/tests/test_models/test_classifiers.py
+++ b/tests/test_models/test_classifiers.py
@@ -321,3 +321,6 @@ def test_classifier_extract_feat():
     outs = model.extract_feats(multi_imgs, stage='pre_logits')
     for out_per_img in outs:
         assert out_per_img.shape == (1, 1024)
+
+    out = model.forward_dummy(torch.rand(1, 3, 224, 224))
+    assert out.shape == (1, 1024)

--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -35,8 +35,8 @@ def main():
     model = build_classifier(cfg.model)
     model.eval()
 
-    if hasattr(model, 'extract_feat'):
-        model.forward = model.extract_feat
+    if hasattr(model, 'forward_dummy'):
+        model.forward = model.forward_dummy
     else:
         raise NotImplementedError(
             'FLOPs counter is currently not currently supported with {}'.


### PR DESCRIPTION
We should add `forward_dummy` to query flops by mmcv (https://github.com/open-mmlab/mmcv/blob/master/mmcv/cnn/utils/flops_counter.py#L38). Althugh we already have `extract_feat`, but it's not sync with mmdetection(https://github.com/open-mmlab/mmdetection/blob/master/mmdet/models/detectors/single_stage.py#L48). 

we should sync both projects since many people may want to put both together into a single project.

 