### PR TITLE
Using train_step instead of forward in PreciseBNHook

### DIFF
--- a/mmcls/core/hook/precise_bn_hook.py
+++ b/mmcls/core/hook/precise_bn_hook.py
@@ -107,7 +107,7 @@ def update_bn_stats(model: nn.Module,
         prog_bar = mmcv.ProgressBar(num_iter)
 
     for data in itertools.islice(loader, num_iter):
-        model(**data)
+        model.train_step(data)
         for i, bn in enumerate(bn_layers):
             running_means[i] += bn.running_mean / num_iter
             running_vars[i] += bn.running_var / num_iter


### PR DESCRIPTION
## Motivation

Using train_step instead of forward in PreciseBNHook, to avoid error when using preciseBNHook in MLU.
refer to #942 

## BC-breaking (Optional)

No

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
