### PR TITLE
[Refactor] Re-write get_sinusoid_encoding from third-party implementation

### DIFF
--- a/mmcls/models/backbones/t2t_vit.py
+++ b/mmcls/models/backbones/t2t_vit.py
@@ -218,27 +218,24 @@ def get_sinusoid_encoding(n_position, embed_dims):
 
     Sinusoid encoding is a kind of relative position encoding method came from
     `Attention Is All You Need<https://arxiv.org/abs/1706.03762>`_.
-
     Args:
         n_position (int): The length of the input token.
         embed_dims (int): The position embedding dimension.
-
     Returns:
         :obj:`torch.FloatTensor`: The sinusoid encoding table.
     """
 
-    def get_position_angle_vec(position):
-        return [
-            position / np.power(10000, 2 * (i // 2) / embed_dims)
-            for i in range(embed_dims)
-        ]
+    vec = torch.arange(embed_dims, dtype=torch.float64)
+    vec = (vec - vec % 2) / embed_dims
+    vec = torch.pow(10000, -vec).view(1, -1)
 
-    sinusoid_table = np.array(
-        [get_position_angle_vec(pos) for pos in range(n_position)])
-    sinusoid_table[:, 0::2] = np.sin(sinusoid_table[:, 0::2])  # dim 2i
-    sinusoid_table[:, 1::2] = np.cos(sinusoid_table[:, 1::2])  # dim 2i+1
+    sinusoid_table = torch.arange(n_position).view(-1, 1) * vec
+    sinusoid_table[:, 0::2].sin_()  # dim 2i
+    sinusoid_table[:, 1::2].cos_()  # dim 2i+1
 
-    return torch.FloatTensor(sinusoid_table).unsqueeze(0)
+    sinusoid_table = sinusoid_table.to(torch.float32)
+
+    return sinusoid_table.unsqueeze(0)
 
 
 @BACKBONES.register_module()


### PR DESCRIPTION
## Motivation

The function `get_sinusoid_encoding` implemented here (https://github.com/open-mmlab/mmclassification/blob/master/mmcls/models/backbones/t2t_vit.py#L216-#L242)  is copied from a third-party implementation (https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/master/transformer/Models.py#L31), while we did not point this out. I re-write the numpy based implementation with pytorch.


## Modification

Rewrite the function at `mmcls/models/backbones/t2t_vit.py` and add the unit test at `tests/test_models/test_backbones/test_t2t_vit.py`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
