### PR TITLE
[Fix] Device mismatch in SwinV2

### DIFF
--- a/mmcls/models/utils/attention.py
+++ b/mmcls/models/utils/attention.py
@@ -261,7 +261,10 @@ class WindowMSAV2(BaseModule):
         attn = (
             F.normalize(q, dim=-1) @ F.normalize(k, dim=-1).transpose(-2, -1))
         logit_scale = torch.clamp(
-            self.logit_scale, max=torch.log(torch.tensor(1. / 0.01))).exp()
+            self.logit_scale,
+            max=torch.log(
+                torch.tensor(1. / 0.01,
+                             device=self.logit_scale.device))).exp()
         attn = attn * logit_scale
 
         relative_position_bias_table = self.cpb_mlp(


### PR DESCRIPTION
## Motivation

Since logit_scale in the WindowMSAV2 module is a learnable parameter and it could potentially be on the GPU, while torch instantiates torch.tensor() on the CPU, this results in an error  :
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument max in method wrapper_clamp_Tensor)`

## Modification

Forced to create a tensor on same device. 

## BC-breaking (Optional)

Currently SwinV2 is not implemented in downstream repositories?

## Use cases
Minimal example to reproduce the error:
```
import torch
from mmcls.models.backbones import SwinTransformerV2
model = SwinTransformerV2().to('cuda:0')
model(torch.rand((2, 3, 512, 512), device='cuda:0'))
```
## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
