### PR TITLE
[Feature] add reduction for neck

### DIFF
--- a/mmcls/models/necks/__init__.py
+++ b/mmcls/models/necks/__init__.py
@@ -2,9 +2,9 @@
 from .gap import GlobalAveragePooling
 from .gem import GeneralizedMeanPooling
 from .hr_fuse import HRFuseScales
-from .reduction import Reduction
+from .reduction import LinearReduction
 
 __all__ = [
     'GlobalAveragePooling', 'GeneralizedMeanPooling', 'HRFuseScales',
-    'Reduction'
+    'LinearReduction'
 ]

--- a/mmcls/models/necks/__init__.py
+++ b/mmcls/models/necks/__init__.py
@@ -2,5 +2,9 @@
 from .gap import GlobalAveragePooling
 from .gem import GeneralizedMeanPooling
 from .hr_fuse import HRFuseScales
+from .reduction import Reduction
 
-__all__ = ['GlobalAveragePooling', 'GeneralizedMeanPooling', 'HRFuseScales']
+__all__ = [
+    'GlobalAveragePooling', 'GeneralizedMeanPooling', 'HRFuseScales',
+    'Reduction'
+]

--- a/mmcls/models/necks/reduction.py
+++ b/mmcls/models/necks/reduction.py
@@ -33,7 +33,7 @@ class LinearReduction(nn.Module):
         super(LinearReduction, self).__init__()
 
         self.in_channels = in_channels
-        self.out_channles = out_channels
+        self.out_channels = out_channels
         self.act_cfg = copy.deepcopy(act_cfg)
         self.norm_cfg = copy.deepcopy(norm_cfg)
         self.init_cfg = copy.deepcopy(init_cfg)

--- a/mmcls/models/necks/reduction.py
+++ b/mmcls/models/necks/reduction.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -49,14 +49,23 @@ class LinearReduction(BaseModule):
         else:
             self.act = nn.Identity()
 
-    def forward(self, inputs):
+    def forward(self, inputs: Union[Tuple,
+                                    torch.Tensor]) -> Tuple[torch.Tensor]:
+        """forward function.
+
+        Args:
+            feats (Union[Tuple, torch.Tensor]): The features extracted from
+                 the backbone. Multiple stage inputs are acceptable but only
+                  the last stage will be used.
+
+        Returns:
+            Tuple(torch.Tensor)): A tuple of reducted features.
+        """
+        assert isinstance(inputs, (tuple, torch.Tensor)), (
+            'The inputs of `LinearReduction` neck  must be tuple or '
+            f'`torch.Tensor`, but get {type(inputs)}.')
         if isinstance(inputs, tuple):
             inputs = inputs[-1]
-        elif isinstance(inputs, torch.Tensor):
-            pass
-        else:
-            raise TypeError(f'neck inputs must be tuple or torch.tensor,'
-                            f' but get {type(inputs)}')
 
-        out = self.reduction(inputs)
-        return self.act(self.norm(out))
+        out = self.act(self.norm(self.reduction(inputs)))
+        return (out, )

--- a/mmcls/models/necks/reduction.py
+++ b/mmcls/models/necks/reduction.py
@@ -18,7 +18,7 @@ class LinearReduction(BaseModule):
         in_channels (int): Number of channels in the input.
         out_channels (int): Number of channels in the output.
         norm_cfg (dict, optional): dictionary to construct and
-            config norm layer. Defaults to None.
+            config norm layer. Defaults to dict(type='BN1d').
         act_cfg (dict, optional): dictionary to construct and
             config activate layer. Defaults to None.
         init_cfg (dict, optional): dictionary to initialize weights.
@@ -28,7 +28,7 @@ class LinearReduction(BaseModule):
     def __init__(self,
                  in_channels: int,
                  out_channels: int,
-                 norm_cfg: Optional[dict] = None,
+                 norm_cfg: Optional[dict] = dict(type='BN1d'),
                  act_cfg: Optional[dict] = None,
                  init_cfg: Optional[dict] = None):
         super(LinearReduction, self).__init__(init_cfg=init_cfg)

--- a/mmcls/models/necks/reduction.py
+++ b/mmcls/models/necks/reduction.py
@@ -1,38 +1,79 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
+
 import torch
 import torch.nn as nn
+from mmcv.cnn import build_activation_layer, build_norm_layer
+from mmengine.model.utils import initialize
 
 from mmcls.registry import MODELS
 
 
 @MODELS.register_module()
-class Reduction(nn.Module):
+class LinearReduction(nn.Module):
     """Neck with Dimension reduction.
 
     Args:
         in_channels (int): Number of channels in the input.
         out_channels (int): Number of channels in the output.
+        act_cfg (dict, optional): dictionary to construct and
+            config activate layer. Default: dict(type='ReLU')
+        norm_cfg (dict, optional): dictionary to construct and
+            config norm layer. Default: dict(type='BN1d')
+        init_cfg (dict, optional): dictionary to initialize weights.
+            Default: None.
     """
 
-    def __init__(self, in_channels: int, out_channels: int):
-        super(Reduction, self).__init__()
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 act_cfg=dict(type='ReLU'),
+                 norm_cfg=dict(type='BN1d'),
+                 init_cfg=None):
+        super(LinearReduction, self).__init__()
+
+        self.in_channels = in_channels
+        self.out_channles = out_channels
+        self.act_cfg = copy.deepcopy(act_cfg)
+        self.norm_cfg = copy.deepcopy(norm_cfg)
+        self.init_cfg = copy.deepcopy(init_cfg)
 
         self.reduction = nn.Linear(
             in_features=in_channels, out_features=out_channels)
-        self.act = nn.SiLU(inplace=True)
-        self.bn = nn.BatchNorm1d(out_channels)
+        if act_cfg:
+            self.act = build_activation_layer(act_cfg)
+        else:
+            self.act = None
+
+        if norm_cfg:
+            self.norm_name, layer = build_norm_layer(norm_cfg, out_channels)
+            self.add_module(self.norm_name, layer)
+        else:
+            self.norm_name = None
+
+    @property
+    def norm(self):
+        if self.norm_name:
+            return getattr(self, self.norm_name)
+        else:
+            return None
+
+    def init_weights(self):
+        if self.init_cfg:
+            initialize(self, self.init_cfg)
 
     def forward(self, inputs):
         if isinstance(inputs, tuple):
             inputs = inputs[-1]
-            out = self.reduction(inputs)
-            out = self.act(out)
-            out = self.bn(out)
         elif isinstance(inputs, torch.Tensor):
-            out = self.reduction(inputs)
-            out = self.act(out)
-            out = self.bn(out)
+            pass
         else:
-            raise TypeError('neck inputs '
-                            'should be torch.tensor or tuple of tensors')
+            raise TypeError(f'neck inputs must be tuple or torch.tensor,'
+                            f' but get {type(inputs)}')
+
+        out = self.reduction(inputs)
+        if self.act_cfg:
+            out = self.act(out)
+        if self.norm_cfg:
+            out = self.norm(out)
         return out

--- a/mmcls/models/necks/reduction.py
+++ b/mmcls/models/necks/reduction.py
@@ -1,66 +1,53 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
+from typing import Optional
 
 import torch
 import torch.nn as nn
 from mmcv.cnn import build_activation_layer, build_norm_layer
-from mmengine.model.utils import initialize
+from mmengine.model import BaseModule
 
 from mmcls.registry import MODELS
 
 
 @MODELS.register_module()
-class LinearReduction(nn.Module):
+class LinearReduction(BaseModule):
     """Neck with Dimension reduction.
 
     Args:
         in_channels (int): Number of channels in the input.
         out_channels (int): Number of channels in the output.
-        act_cfg (dict, optional): dictionary to construct and
-            config activate layer. Default: dict(type='ReLU')
         norm_cfg (dict, optional): dictionary to construct and
-            config norm layer. Default: dict(type='BN1d')
+            config norm layer. Defaults to None.
+        act_cfg (dict, optional): dictionary to construct and
+            config activate layer. Defaults to None.
         init_cfg (dict, optional): dictionary to initialize weights.
-            Default: None.
+            Defaults to None.
     """
 
     def __init__(self,
-                 in_channels,
-                 out_channels,
-                 act_cfg=dict(type='ReLU'),
-                 norm_cfg=dict(type='BN1d'),
-                 init_cfg=None):
-        super(LinearReduction, self).__init__()
+                 in_channels: int,
+                 out_channels: int,
+                 norm_cfg: Optional[dict] = None,
+                 act_cfg: Optional[dict] = None,
+                 init_cfg: Optional[dict] = None):
+        super(LinearReduction, self).__init__(init_cfg=init_cfg)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
-        self.act_cfg = copy.deepcopy(act_cfg)
         self.norm_cfg = copy.deepcopy(norm_cfg)
-        self.init_cfg = copy.deepcopy(init_cfg)
+        self.act_cfg = copy.deepcopy(act_cfg)
 
         self.reduction = nn.Linear(
             in_features=in_channels, out_features=out_channels)
+        if norm_cfg:
+            self.norm = build_norm_layer(norm_cfg, out_channels)[1]
+        else:
+            self.norm = nn.Identity()
         if act_cfg:
             self.act = build_activation_layer(act_cfg)
         else:
-            self.act = None
-
-        if norm_cfg:
-            self.norm_name, layer = build_norm_layer(norm_cfg, out_channels)
-            self.add_module(self.norm_name, layer)
-        else:
-            self.norm_name = None
-
-    @property
-    def norm(self):
-        if self.norm_name:
-            return getattr(self, self.norm_name)
-        else:
-            return None
-
-    def init_weights(self):
-        if self.init_cfg:
-            initialize(self, self.init_cfg)
+            self.act = nn.Identity()
 
     def forward(self, inputs):
         if isinstance(inputs, tuple):
@@ -72,8 +59,4 @@ class LinearReduction(nn.Module):
                             f' but get {type(inputs)}')
 
         out = self.reduction(inputs)
-        if self.act_cfg:
-            out = self.act(out)
-        if self.norm_cfg:
-            out = self.norm(out)
-        return out
+        return self.act(self.norm(out))

--- a/mmcls/models/necks/reduction.py
+++ b/mmcls/models/necks/reduction.py
@@ -54,7 +54,7 @@ class LinearReduction(BaseModule):
         """forward function.
 
         Args:
-            feats (Union[Tuple, torch.Tensor]): The features extracted from
+            inputs (Union[Tuple, torch.Tensor]): The features extracted from
                  the backbone. Multiple stage inputs are acceptable but only
                   the last stage will be used.
 

--- a/mmcls/models/necks/reduction.py
+++ b/mmcls/models/necks/reduction.py
@@ -1,0 +1,38 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+import torch.nn as nn
+
+from mmcls.registry import MODELS
+
+
+@MODELS.register_module()
+class Reduction(nn.Module):
+    """Neck with Dimension reduction.
+
+    Args:
+        in_channels (int): Number of channels in the input.
+        out_channels (int): Number of channels in the output.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int):
+        super(Reduction, self).__init__()
+
+        self.reduction = nn.Linear(
+            in_features=in_channels, out_features=out_channels)
+        self.act = nn.SiLU(inplace=True)
+        self.bn = nn.BatchNorm1d(out_channels)
+
+    def forward(self, inputs):
+        if isinstance(inputs, tuple):
+            inputs = inputs[-1]
+            out = self.reduction(inputs)
+            out = self.act(out)
+            out = self.bn(out)
+        elif isinstance(inputs, torch.Tensor):
+            out = self.reduction(inputs)
+            out = self.act(out)
+            out = self.bn(out)
+        else:
+            raise TypeError('neck inputs '
+                            'should be torch.tensor or tuple of tensors')
+        return out

--- a/tests/test_models/test_necks.py
+++ b/tests/test_models/test_necks.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from mmcls.models.necks import (GeneralizedMeanPooling, GlobalAveragePooling,
-                                HRFuseScales)
+                                HRFuseScales, Reduction)
 
 
 def test_gap_neck():
@@ -85,3 +85,25 @@ def test_hr_fuse_scales():
     assert isinstance(outs, tuple)
     assert len(outs) == 1
     assert outs[0].shape == (3, 1024, 7, 7)
+
+
+def test_reduction():
+    # test neck_with_reduction
+    neck = Reduction(10, 5)
+    neck.eval()
+
+    # batch_size, in_channels, out_channels
+    fake_input = torch.rand(1, 10)
+    output = neck(fake_input)
+    # batch_size, out_features
+    assert output.shape == (1, 5)
+
+    # batch_size, in_features, feature_size(2)
+    fake_input = (torch.rand(1, 20), torch.rand(1, 10))
+
+    output = neck(fake_input)
+    # batch_size, out_features
+    assert output.shape == (1, 5)
+
+    with pytest.raises(TypeError):
+        neck([])

--- a/tests/test_models/test_necks.py
+++ b/tests/test_models/test_necks.py
@@ -98,14 +98,14 @@ def test_linear_reduction():
     fake_input = torch.rand(1, 10)
     output = neck(fake_input)
     # batch_size, out_features
-    assert output.shape == (1, 5)
+    assert output[-1].shape == (1, 5)
 
     # batch_size, in_features, feature_size(2)
     fake_input = (torch.rand(1, 20), torch.rand(1, 10))
 
     output = neck(fake_input)
     # batch_size, out_features
-    assert output.shape == (1, 5)
+    assert output[-1].shape == (1, 5)
 
     # test linear_reduction with `init_cfg`
     neck = LinearReduction(
@@ -123,14 +123,14 @@ def test_linear_reduction():
     fake_input = torch.rand(1, 10)
     output = neck(fake_input)
     # batch_size, out_features
-    assert output.shape == (1, 5)
+    assert output[-1].shape == (1, 5)
     #
     # # batch_size, in_features, feature_size(2)
     fake_input = (torch.rand(1, 20), torch.rand(1, 10))
 
     output = neck(fake_input)
     # batch_size, out_features
-    assert output.shape == (1, 5)
+    assert output[-1].shape == (1, 5)
 
     with pytest.raises(TypeError):
         neck([])

--- a/tests/test_models/test_necks.py
+++ b/tests/test_models/test_necks.py
@@ -90,10 +90,9 @@ def test_hr_fuse_scales():
 def test_linear_reduction():
     # test linear_reduction without `act_cfg` and `norm_cfg`
     neck = LinearReduction(10, 5, None, None)
-    assert neck.init_weights() is None
     neck.eval()
-    assert neck.act is None
-    assert neck.norm is None
+    assert isinstance(neck.act, torch.nn.Identity)
+    assert isinstance(neck.norm, torch.nn.Identity)
 
     # batch_size, in_channels, out_channels
     fake_input = torch.rand(1, 10)
@@ -111,7 +110,6 @@ def test_linear_reduction():
     # test linear_reduction with `init_cfg`
     neck = LinearReduction(
         10, 5, init_cfg=dict(type='Xavier', layer=['Linear']))
-    assert neck.init_weights() is None
 
     # test linear_reduction with `act_cfg` and `norm_cfg`
     neck = LinearReduction(

--- a/tests/test_models/test_necks.py
+++ b/tests/test_models/test_necks.py
@@ -132,5 +132,5 @@ def test_linear_reduction():
     # batch_size, out_features
     assert output[-1].shape == (1, 5)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         neck([])


### PR DESCRIPTION
## Motivation

In some cases, it is necessary to reduce the dimension of extracted feature, so ``Reduction`` is implemented in necks.

## Use cases

```python
model = dict(
    type='ImageClassifier',
    backbone=dict(
        type='ResNet',
        depth=101,
        num_stages=4,
        out_indices=(3,),
        style='pytorch'
    ),
    neck=[
        dict(type='GeneralizedMeanPooling'),
        dict(type='LinearReduction',
             in_channels=2048,
             out_channels=512,
             act_cfg=dict(type='ReLU'),
             norm_cfg=dict(type='BN1d')
             )
    ],
    head=dict(
        type='LinearClsHead',
        num_classes=1000,
        in_channels=2304,
        loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
        topk=(1, 5),
    ),
)

```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
