### PR TITLE
[Feature] Support InShop Dataset (Image Retrieval).

### DIFF
--- a/docs/en/api/datasets.rst
+++ b/docs/en/api/datasets.rst
@@ -50,7 +50,7 @@ CUB
 .. autoclass:: CUB
 
 Retrieval
----
+---------
 
 .. autoclass:: InShop
 

--- a/docs/en/api/datasets.rst
+++ b/docs/en/api/datasets.rst
@@ -49,6 +49,11 @@ CUB
 
 .. autoclass:: CUB
 
+Retrieval
+---
+
+.. autoclass:: InShop
+
 Base classes
 ------------
 

--- a/mmcls/datasets/__init__.py
+++ b/mmcls/datasets/__init__.py
@@ -6,6 +6,7 @@ from .cub import CUB
 from .custom import CustomDataset
 from .dataset_wrappers import KFoldDataset
 from .imagenet import ImageNet, ImageNet21k
+from .inshop import InShop
 from .mnist import MNIST, FashionMNIST
 from .multi_label import MultiLabelDataset
 from .multi_task import MultiTaskDataset
@@ -16,5 +17,5 @@ from .voc import VOC
 __all__ = [
     'BaseDataset', 'ImageNet', 'CIFAR10', 'CIFAR100', 'MNIST', 'FashionMNIST',
     'VOC', 'build_dataset', 'ImageNet21k', 'KFoldDataset', 'CUB',
-    'CustomDataset', 'MultiLabelDataset', 'MultiTaskDataset'
+    'CustomDataset', 'MultiLabelDataset', 'MultiTaskDataset', 'InShop'
 ]

--- a/mmcls/datasets/inshop.py
+++ b/mmcls/datasets/inshop.py
@@ -1,0 +1,173 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from mmengine import FileClient
+
+from mmcls.registry import DATASETS
+from .base_dataset import BaseDataset
+
+
+@DATASETS.register_module()
+class InShop(BaseDataset):
+    """InShop Dataset for Image Retrieval.
+
+    Please download the images from
+    'https://mmlab.ie.cuhk.edu.hk/projects/DeepFashion/InShopRetrieval.html'
+    and organize them as follows:
+
+        In-shop Clothes Retrieval Benchmark (data_root)/
+           ├── Anno /
+           ├── Eval /
+           ├── Img
+           │   └── img/
+           ├── README.txt
+           └── list_eval_partition.txt (ann_file)
+
+    Args:
+        data_root (str): The root directory for dataset
+        mode (str): The value is in 'train', 'query' and 'gallery'.
+            Defaults to 'train'.
+        ann_file (str): Annotation file path, path relative to
+            ``data_root``. Defaults to 'list_eval_partition.txt'.
+        **kwargs: Other keyword arguments in :class:`BaseDataset`.
+
+    Examples:
+        >>> from mmcls.datasets import InShop
+        >>> inshop_train_cfg = dict(data_root='data/inshop', \
+        >>> ... mode='train')
+        >>> inshop_train = InShop(**inshop_train_cfg)
+        >>> inshop_train
+        Dataset InShop
+            Number of samples:  25882
+            The `CLASSES` meta info is not set.
+            Root of dataset:    data/inshop
+        >>> from mmcls.datasets import InShop
+        >>> inshop_query_cfg = dict(data_root='data/inshop', \
+        >>> ... mode='query')
+        >>> inshop_query = InShop(**inshop_query_cfg)
+        >>> inshop_query
+        Dataset InShop
+            Number of samples:  14218
+            The `CLASSES` meta info is not set.
+            Root of dataset:    data/inshop
+        >>> from mmcls.datasets import InShop
+        >>> inshop_gallery_cfg = dict(data_root='data/inshop',\
+        >>> ... mode='gallery')
+        >>> inshop_gallery = InShop(**inshop_gallery_cfg)
+        >>> inshop_gallery
+        Dataset InShop
+            Number of samples:  12612
+            The `CLASSES` meta info is not set.
+            Root of dataset:    data/inshop
+    """
+
+    def __init__(self,
+                 data_root: str = 'data/inshop',
+                 mode: str = 'train',
+                 ann_file: str = 'list_eval_partition.txt',
+                 **kwargs):
+
+        assert mode in ['train', 'query', 'gallery'], \
+            '``{}`` is an illegal mode'.format(mode)
+        test_mode = False if mode == 'train' else True
+        self.file_client = FileClient.infer_client(uri=data_root)
+        self.ann_file = self.file_client.join_path(data_root, ann_file)
+        self.data_root = data_root
+        self.mode = mode
+        super().__init__(
+            data_root=data_root,
+            test_mode=test_mode,
+            ann_file=ann_file,
+            **kwargs)
+
+    def _process_annotations(self):
+        path = self.file_client.join_path(self.data_root, self.ann_file)
+        anno_train = {'metainfo': {}, 'data_list': []}
+        anno_query = {'metainfo': {}, 'data_list': []}
+        anno_gallery = {'metainfo': {}, 'data_list': []}
+        lines = self.file_client.get_text(path).strip()
+        lines = lines.split('\n')
+
+        # item_id to label, each item corresponds to one class label
+        class_num = 0
+        gt_label_train = {}
+
+        # item_id to label, each label corresponds to several items
+        gallery_num = 0
+        gt_label_gallery = {}
+
+        for line in lines[2:]:
+            # The first line (lines[0]) is the image number
+            # and the second line (lines[1]) is the field name,
+            # so process the sample from the third line (lines[2]).
+            # Each line is formatted as follows,
+            # ``image_name, item_id, evaluation_status``,
+            # such as ``02_1_front.jpg id_001 train``.
+            img_name, item_id, status = line.split()
+            if status == 'train':
+                if item_id not in gt_label_train:
+                    gt_label_train[item_id] = class_num
+                    class_num += 1
+                # item_id to class_id (for the training set)
+                anno_train['data_list'].append({
+                    'img_path':
+                    f'{self.data_root}/Img/{img_name}',
+                    'gt_label':
+                    gt_label_train[item_id],
+                })
+            elif status == 'gallery':
+                if item_id not in gt_label_gallery:
+                    gt_label_gallery[item_id] = []
+                # Since there are multiple images for each item,
+                # record the corresponding item for each image.
+                gt_label_gallery[item_id].append(gallery_num)
+                anno_gallery['data_list'].append({
+                    'img_path': f'{self.data_root}/Img/{img_name}',
+                    'img_id': gallery_num
+                })
+                gallery_num += 1
+            else:
+                continue
+
+        # Generate the label for the query set
+        query_num = 0
+        for line in lines[2:]:
+            img_name, item_id, status = line.split()
+            if status == 'query':
+                anno_query['data_list'].append({
+                    'img_path':
+                    f'{self.data_root}/Img/{img_name}',
+                    'gt_label':
+                    gt_label_gallery[item_id],
+                })
+                query_num += 1
+            else:
+                continue
+
+        if self.mode == 'train':
+            anno_train['metainfo']['class_number'] = class_num
+            anno_train['metainfo']['sample_number'] = \
+                len(anno_train['data_list'])
+            return anno_train
+        elif self.mode == 'query':
+            anno_query['metainfo']['sample_number'] = query_num
+            return anno_query
+        else:
+            anno_gallery['metainfo']['sample_number'] = gallery_num
+            return anno_gallery
+
+    def load_data_list(self):
+        """For the train set, return image and ground truth label.
+
+        For the query set, return image and ids of images in gallery. For the
+        gallery set, return image and its id.
+        """
+        data_info = self._process_annotations()
+        data_list = data_info['data_list']
+        for data in data_list:
+            data['img_path'] = self.file_client.join_path(
+                self.data_root, data['img_path'])
+        return data_list
+
+    def extra_repr(self):
+        """The extra repr information of the dataset."""
+        body = [f'Root of dataset: \t{self.data_root}']
+        return body

--- a/mmcls/datasets/inshop.py
+++ b/mmcls/datasets/inshop.py
@@ -26,7 +26,7 @@ class InShop(BaseDataset):
         data_root (str): The root directory for dataset.
         split (str): Choose from 'train', 'query' and 'gallery'.
             Defaults to 'train'.
-        data_prefix (str | dict): Prefix for training data. 
+        data_prefix (str | dict): Prefix for training data.
             Defaults to 'Img/img'.
         ann_file (str): Annotation file path, path relative to
             ``data_root``. Defaults to 'Eval/list_eval_partition.txt'.
@@ -34,26 +34,27 @@ class InShop(BaseDataset):
 
     Examples:
         >>> from mmcls.datasets import InShop
-        >>> inshop_train_cfg = dict(data_root='data/inshop', \
-        >>> ... split='train')
+        >>>
+        >>> # build train InShop dataset
+        >>> inshop_train_cfg = dict(data_root='data/inshop', split='train')
         >>> inshop_train = InShop(**inshop_train_cfg)
         >>> inshop_train
         Dataset InShop
             Number of samples:  25882
             The `CLASSES` meta info is not set.
             Root of dataset:    data/inshop
-        >>> from mmcls.datasets import InShop
-        >>> inshop_query_cfg = dict(data_root='data/inshop', \
-        >>> ... split='query')
+        >>>
+        >>> # build query InShop dataset
+        >>> inshop_query_cfg =  dict(data_root='data/inshop', split='query')
         >>> inshop_query = InShop(**inshop_query_cfg)
         >>> inshop_query
         Dataset InShop
             Number of samples:  14218
             The `CLASSES` meta info is not set.
             Root of dataset:    data/inshop
-        >>> from mmcls.datasets import InShop
-        >>> inshop_gallery_cfg = dict(data_root='data/inshop',\
-        >>> ... split='gallery')
+        >>>
+        >>> # build gallery InShop dataset
+        >>> inshop_gallery_cfg = dict(data_root='data/inshop', split='gallery')
         >>> inshop_gallery = InShop(**inshop_gallery_cfg)
         >>> inshop_gallery
         Dataset InShop
@@ -72,20 +73,18 @@ class InShop(BaseDataset):
         assert split in ('train', 'query', 'gallery'), "'split' of `InShop`" \
             f" must be one of ['train', 'query', 'gallery'], bu get '{split}'"
         self.backend = get_file_backend(data_root, enable_singleton=True)
+        self.split = split
         super().__init__(
             data_root=data_root,
             data_prefix=data_prefix,
             ann_file=ann_file,
             **kwargs)
 
-        self.split = split
-
     def _process_annotations(self):
-        ann_path = self.backend.join_path(self.data_root, self.ann_file)
-        anno_train = {'metainfo': {}, 'data_list': []}
-        anno_query = {'metainfo': {}, 'data_list': []}
-        anno_gallery = {'metainfo': {}, 'data_list': []}
-        lines = list_from_file(ann_path)
+        lines = list_from_file(self.ann_file)
+
+        anno_train = dict(metainfo=dict(), data_list=list())
+        anno_gallery = dict(metainfo=dict(), data_list=list())
 
         # item_id to label, each item corresponds to one class label
         class_num = 0
@@ -95,71 +94,58 @@ class InShop(BaseDataset):
         gallery_num = 0
         gt_label_gallery = {}
 
+        # (lines[0], lines[1]) is the image number and the field name;
+        # Each line format as 'image_name, item_id, evaluation_status'
         for line in lines[2:]:
-            # The first line (lines[0]) is the image number
-            # and the second line (lines[1]) is the field name,
-            # so process the sample from the third line (lines[2]).
-            # Each line is formatted as follows,
-            # ``image_name, item_id, evaluation_status``,
-            # such as ``02_1_front.jpg id_001 train``.
             img_name, item_id, status = line.split()
+            img_path = self.backend.join_path(self.img_prefix, img_name)
             if status == 'train':
                 if item_id not in gt_label_train:
                     gt_label_train[item_id] = class_num
                     class_num += 1
                 # item_id to class_id (for the training set)
-                anno_train['data_list'].append({
-                    'img_path':
-                    f'{self.data_root}/Img/{img_name}',
-                    'gt_label':
-                    gt_label_train[item_id],
-                })
+                anno_train['data_list'].append(
+                    dict(img_path=img_path, gt_label=gt_label_train[item_id]))
             elif status == 'gallery':
                 if item_id not in gt_label_gallery:
                     gt_label_gallery[item_id] = []
                 # Since there are multiple images for each item,
                 # record the corresponding item for each image.
                 gt_label_gallery[item_id].append(gallery_num)
-                anno_gallery['data_list'].append({
-                    'img_path': f'{self.data_root}/Img/{img_name}',
-                    'sample_idx': gallery_num
-                })
+                anno_gallery['data_list'].append(
+                    dict(img_path=img_path, sample_idx=gallery_num))
                 gallery_num += 1
-            else:
-                continue
-
-        # Generate the label for the query set
-        query_num = 0
-        for line in lines[2:]:
-            img_name, item_id, status = line.split()
-            if status == 'query':
-                anno_query['data_list'].append({
-                    'img_path':
-                    f'{self.data_root}/Img/{img_name}',
-                    'gt_label':
-                    gt_label_gallery[item_id],
-                })
-                query_num += 1
-            else:
-                continue
 
         if self.split == 'train':
             anno_train['metainfo']['class_number'] = class_num
             anno_train['metainfo']['sample_number'] = \
                 len(anno_train['data_list'])
             return anno_train
-        elif self.split == 'query':
-            anno_query['metainfo']['sample_number'] = query_num
-            return anno_query
-        else:
+        elif self.split == 'gallery':
             anno_gallery['metainfo']['sample_number'] = gallery_num
             return anno_gallery
 
-    def load_data_list(self):
-        """For the train set, return image and ground truth label.
+        # Generate the label for the query(val) set
+        anno_query = dict(metainfo=dict(), data_list=list())
+        query_num = 0
+        for line in lines[2:]:
+            img_name, item_id, status = line.split()
+            img_path = self.backend.join_path(self.img_prefix, img_name)
+            if status == 'query':
+                anno_query['data_list'].append(
+                    dict(
+                        img_path=img_path, gt_label=gt_label_gallery[item_id]))
+                query_num += 1
 
-        For the query set, return image and ids of images in gallery. For the
-        gallery set, return image and its id.
+        anno_query['metainfo']['sample_number'] = query_num
+        return anno_query
+
+    def load_data_list(self):
+        """load data list.
+
+        For the train set, return image and ground truth label. For the query
+        set, return image and ids of images in gallery. For the gallery set,
+        return image and its id.
         """
         data_info = self._process_annotations()
         data_list = data_info['data_list']

--- a/mmcls/datasets/inshop.py
+++ b/mmcls/datasets/inshop.py
@@ -121,7 +121,7 @@ class InShop(BaseDataset):
                 gt_label_gallery[item_id].append(gallery_num)
                 anno_gallery['data_list'].append({
                     'img_path': f'{self.data_root}/Img/{img_name}',
-                    'img_id': gallery_num
+                    'sample_idx': gallery_num
                 })
                 gallery_num += 1
             else:

--- a/tests/test_datasets/test_datasets.py
+++ b/tests/test_datasets/test_datasets.py
@@ -924,6 +924,20 @@ class TestMultiTaskDataset(TestCase):
         task_doc = ('For 2 tasks\n     gender \n     wear ')
         self.assertIn(task_doc, repr(dataset))
 
+    def test_load_data_list(self):
+        dataset_class = DATASETS.get(self.DATASET_TYPE)
+
+        # Test default behavior
+        dataset = dataset_class(**self.DEFAULT_ARGS)
+        data = dataset.load_data_list(self.DEFAULT_ARGS['ann_file'])
+        self.assertIsInstance(data, list)
+        np.testing.assert_equal(len(data), 3)
+        np.testing.assert_equal(data[0]['gt_label'], {'gender': 0})
+        np.testing.assert_equal(data[1]['gt_label'], {
+            'gender': 0,
+            'wear': [1, 0, 1, 0]
+        })
+
 
 class TestInShop(TestBaseDataset):
     DATASET_TYPE = 'InShop'

--- a/tests/test_datasets/test_datasets.py
+++ b/tests/test_datasets/test_datasets.py
@@ -923,6 +923,8 @@ class TestMultiTaskDataset(TestCase):
 
         task_doc = ('For 2 tasks\n     gender \n     wear ')
         self.assertIn(task_doc, repr(dataset))
+
+
 class TestInShop(TestBaseDataset):
     DATASET_TYPE = 'InShop'
 

--- a/tests/test_datasets/test_datasets.py
+++ b/tests/test_datasets/test_datasets.py
@@ -1010,7 +1010,7 @@ class TestInShop(TestBaseDataset):
         data_info = dataset[0]
         self.assertEqual(data_info['img_path'],
                          f'{self.root}/Img/12_3_back.jpg')
-        self.assertEqual(data_info['img_id'], 0)
+        self.assertEqual(data_info['sample_idx'], 0)
 
     def test_extra_repr(self):
         dataset_class = DATASETS.get(self.DATASET_TYPE)

--- a/tests/test_datasets/test_datasets.py
+++ b/tests/test_datasets/test_datasets.py
@@ -933,9 +933,10 @@ class TestInShop(TestBaseDataset):
         tmpdir = tempfile.TemporaryDirectory()
         cls.tmpdir = tmpdir
         cls.root = tmpdir.name
-        cls.list_eval_partition = 'list_eval_partition.txt'
-        cls.DEFAULT_ARGS = dict(data_root=cls.root, mode='train')
+        cls.list_eval_partition = 'Eval/list_eval_partition.txt'
+        cls.DEFAULT_ARGS = dict(data_root=cls.root, split='train')
         cls.ann_file = osp.join(cls.root, cls.list_eval_partition)
+        os.makedirs(osp.join(cls.root, 'Eval'))
         with open(cls.ann_file, 'w') as f:
             f.write('\n'.join([
                 '8',
@@ -956,30 +957,27 @@ class TestInShop(TestBaseDataset):
         # Test with mode=train
         cfg = {**self.DEFAULT_ARGS}
         dataset = dataset_class(**cfg)
-        self.assertEqual(dataset.mode, 'train')
-        self.assertFalse(dataset.test_mode)
+        self.assertEqual(dataset.split, 'train')
         self.assertEqual(dataset.data_root, self.root)
         self.assertEqual(dataset.ann_file, self.ann_file)
 
         # Test with mode=query
-        cfg = {**self.DEFAULT_ARGS, 'mode': 'query'}
+        cfg = {**self.DEFAULT_ARGS, 'split': 'query'}
         dataset = dataset_class(**cfg)
-        self.assertEqual(dataset.mode, 'query')
-        self.assertTrue(dataset.test_mode)
+        self.assertEqual(dataset.split, 'query')
         self.assertEqual(dataset.data_root, self.root)
         self.assertEqual(dataset.ann_file, self.ann_file)
 
         # Test with mode=gallery
-        cfg = {**self.DEFAULT_ARGS, 'mode': 'gallery'}
+        cfg = {**self.DEFAULT_ARGS, 'split': 'gallery'}
         dataset = dataset_class(**cfg)
-        self.assertEqual(dataset.mode, 'gallery')
-        self.assertTrue(dataset.test_mode)
+        self.assertEqual(dataset.split, 'gallery')
         self.assertEqual(dataset.data_root, self.root)
         self.assertEqual(dataset.ann_file, self.ann_file)
 
         # Test with mode=other
-        cfg = {**self.DEFAULT_ARGS, 'mode': 'other'}
-        with self.assertRaisesRegex(AssertionError, 'illegal mode'):
+        cfg = {**self.DEFAULT_ARGS, 'split': 'other'}
+        with self.assertRaisesRegex(AssertionError, "'split' of `InS"):
             dataset_class(**cfg)
 
     def test_load_data_list(self):
@@ -991,25 +989,25 @@ class TestInShop(TestBaseDataset):
         self.assertEqual(len(dataset), 2)
         data_info = dataset[0]
         self.assertEqual(data_info['img_path'],
-                         f'{self.root}/Img/02_1_front.jpg')
+                         f'{self.root}/Img/img/02_1_front.jpg')
         self.assertEqual(data_info['gt_label'], 0)
 
         # Test with mode=query
-        cfg = {**self.DEFAULT_ARGS, 'mode': 'query'}
+        cfg = {**self.DEFAULT_ARGS, 'split': 'query'}
         dataset = dataset_class(**cfg)
         self.assertEqual(len(dataset), 3)
         data_info = dataset[0]
         self.assertEqual(data_info['img_path'],
-                         f'{self.root}/Img/13_1_front.jpg')
+                         f'{self.root}/Img/img/13_1_front.jpg')
         self.assertEqual(data_info['gt_label'], [0, 1])
 
         # Test with mode=gallery
-        cfg = {**self.DEFAULT_ARGS, 'mode': 'gallery'}
+        cfg = {**self.DEFAULT_ARGS, 'split': 'gallery'}
         dataset = dataset_class(**cfg)
         self.assertEqual(len(dataset), 3)
         data_info = dataset[0]
         self.assertEqual(data_info['img_path'],
-                         f'{self.root}/Img/12_3_back.jpg')
+                         f'{self.root}/Img/img/12_3_back.jpg')
         self.assertEqual(data_info['sample_idx'], 0)
 
     def test_extra_repr(self):

--- a/tests/test_datasets/test_datasets.py
+++ b/tests/test_datasets/test_datasets.py
@@ -988,8 +988,9 @@ class TestInShop(TestBaseDataset):
         dataset = dataset_class(**cfg)
         self.assertEqual(len(dataset), 2)
         data_info = dataset[0]
-        self.assertEqual(data_info['img_path'],
-                         f'{self.root}/Img/img/02_1_front.jpg')
+        self.assertEqual(
+            data_info['img_path'],
+            os.path.join(self.root, 'Img', 'img', '02_1_front.jpg'))
         self.assertEqual(data_info['gt_label'], 0)
 
         # Test with mode=query
@@ -997,8 +998,9 @@ class TestInShop(TestBaseDataset):
         dataset = dataset_class(**cfg)
         self.assertEqual(len(dataset), 3)
         data_info = dataset[0]
-        self.assertEqual(data_info['img_path'],
-                         f'{self.root}/Img/img/13_1_front.jpg')
+        self.assertEqual(
+            data_info['img_path'],
+            os.path.join(self.root, 'Img', 'img', '13_1_front.jpg'))
         self.assertEqual(data_info['gt_label'], [0, 1])
 
         # Test with mode=gallery
@@ -1006,8 +1008,9 @@ class TestInShop(TestBaseDataset):
         dataset = dataset_class(**cfg)
         self.assertEqual(len(dataset), 3)
         data_info = dataset[0]
-        self.assertEqual(data_info['img_path'],
-                         f'{self.root}/Img/img/12_3_back.jpg')
+        self.assertEqual(
+            data_info['img_path'],
+            os.path.join(self.root, self.root, 'Img', 'img', '12_3_back.jpg'))
         self.assertEqual(data_info['sample_idx'], 0)
 
     def test_extra_repr(self):

--- a/tests/test_datasets/test_datasets.py
+++ b/tests/test_datasets/test_datasets.py
@@ -988,9 +988,8 @@ class TestInShop(TestBaseDataset):
         dataset = dataset_class(**cfg)
         self.assertEqual(len(dataset), 2)
         data_info = dataset[0]
-        self.assertEqual(
-            data_info['img_path'],
-            os.path.join(self.root, 'Img', 'img', '02_1_front.jpg'))
+        self.assertEqual(data_info['img_path'],
+                         os.path.join(self.root, 'Img/img', '02_1_front.jpg'))
         self.assertEqual(data_info['gt_label'], 0)
 
         # Test with mode=query
@@ -998,9 +997,8 @@ class TestInShop(TestBaseDataset):
         dataset = dataset_class(**cfg)
         self.assertEqual(len(dataset), 3)
         data_info = dataset[0]
-        self.assertEqual(
-            data_info['img_path'],
-            os.path.join(self.root, 'Img', 'img', '13_1_front.jpg'))
+        self.assertEqual(data_info['img_path'],
+                         os.path.join(self.root, 'Img/img', '13_1_front.jpg'))
         self.assertEqual(data_info['gt_label'], [0, 1])
 
         # Test with mode=gallery
@@ -1010,7 +1008,7 @@ class TestInShop(TestBaseDataset):
         data_info = dataset[0]
         self.assertEqual(
             data_info['img_path'],
-            os.path.join(self.root, self.root, 'Img', 'img', '12_3_back.jpg'))
+            os.path.join(self.root, self.root, 'Img/img', '12_3_back.jpg'))
         self.assertEqual(data_info['sample_idx'], 0)
 
     def test_extra_repr(self):


### PR DESCRIPTION
## Motivation

Support [InShop dataset](https://mmlab.ie.cuhk.edu.hk/projects/DeepFashion/InShopRetrieval.html) .

### Example

```
>>> from mmcls.data import InShop

>>> data_root = 'data/inshop'
>>> inshop_train_cfg = dict(data_root='data/inshop', split='train')
>>> inshop_train = InShop(**inshop_train_cfg)
>>> len(inshop_train)
25882
>>> inshop_query_cfg = dict(data_root='data/inshop', split='query')
>>> inshop_query = InShop(**inshop_query_cfg)
>>> len(inshop_query)
14218
>>> inshop_gallery_cfg = dict(data_root='data/inshop', split='gallery')
>>> inshop_gallery = InShop(**inshop_gallery_cfg)
>>> len(inshop_gallery)
12612
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
