### PR TITLE
[Enhancement] RepVGG for YOLOX-PAI

### DIFF
--- a/mmcls/models/backbones/repvgg.py
+++ b/mmcls/models/backbones/repvgg.py
@@ -311,7 +311,7 @@ class RepVGG(BaseBackbone):
     <https://arxiv.org/abs/2101.03697>`_
 
     Args:
-        arch (str | dict): The parameter of RepVGG.
+        arch (str | dict): RepVGG architecture.
             If it's a dict, it should contain the following keys:
 
             - num_blocks (Sequence[int]): Number of blocks in each stage.

--- a/mmcls/models/utils/attention.py
+++ b/mmcls/models/utils/attention.py
@@ -261,7 +261,10 @@ class WindowMSAV2(BaseModule):
         attn = (
             F.normalize(q, dim=-1) @ F.normalize(k, dim=-1).transpose(-2, -1))
         logit_scale = torch.clamp(
-            self.logit_scale, max=torch.log(torch.tensor(1. / 0.01))).exp()
+            self.logit_scale,
+            max=torch.log(
+                torch.tensor(1. / 0.01,
+                             device=self.logit_scale.device))).exp()
         attn = attn * logit_scale
 
         relative_position_bias_table = self.cpb_mlp(

--- a/tests/test_models/test_backbones/test_repvgg.py
+++ b/tests/test_models/test_backbones/test_repvgg.py
@@ -275,6 +275,22 @@ def test_repvgg_backbone():
             torch.allclose(feat[i], feat_deploy[i])
         torch.allclose(pred, pred_deploy)
 
+    # Test RepVGG forward with add_ppf
+    model = RepVGG('A0', out_indices=(3, ), add_ppf=True)
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert isinstance(feat, tuple)
+    assert len(feat) == 1
+    assert isinstance(feat[0], torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 1280, 7, 7))
+
 
 def test_repvgg_load():
     # Test output before and load from deploy checkpoint

--- a/tests/test_models/test_backbones/test_repvgg.py
+++ b/tests/test_models/test_backbones/test_repvgg.py
@@ -291,6 +291,30 @@ def test_repvgg_backbone():
     assert isinstance(feat[0], torch.Tensor)
     assert feat[0].shape == torch.Size((1, 1280, 7, 7))
 
+    # Test RepVGG forward with base_channels is None and arch['base_channels']
+    # is None
+    arch = dict(
+        num_blocks=[2, 4, 14, 1],
+        width_factor=[0.75, 0.75, 0.75, 2.5],
+        group_layer_map=None,
+        se_cfg=None,
+        min_stem_channels=64,
+        base_channels=None)
+    model = RepVGG(arch, out_indices=(3, ), add_ppf=True)
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert isinstance(feat, tuple)
+    assert len(feat) == 1
+    assert isinstance(feat[0], torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 1280, 7, 7))
+
 
 def test_repvgg_load():
     # Test output before and load from deploy checkpoint


### PR DESCRIPTION
## Motivation

Add `MTSPPF` block and `add_ppf` param for YOLOX-PAI.
[YOLOX-PAI: An Improved YOLOX, Stronger and Faster than YOLOv6](https://arxiv.org/abs/2208.13040)
[official repo](https://github.com/alibaba/EasyCV/tree/master/configs/detection/yolox)

## Modification
1. add MTSPPF module and support it in RepVGG backbone;
2. support 'stem_channels' in `arch` and add a 'yolox-pai-small' arch cfg
3. Reduce the number of channels to speed up unit testing

## Related PR

https://github.com/open-mmlab/mmdetection/pull/8778

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
