### PR TITLE
[Fix] fix attention clamp max params

### DIFF
--- a/mmcls/models/utils/attention.py
+++ b/mmcls/models/utils/attention.py
@@ -261,10 +261,7 @@ class WindowMSAV2(BaseModule):
         attn = (
             F.normalize(q, dim=-1) @ F.normalize(k, dim=-1).transpose(-2, -1))
         logit_scale = torch.clamp(
-            self.logit_scale,
-            max=torch.log(
-                torch.tensor(1. / 0.01,
-                             device=self.logit_scale.device))).exp()
+            self.logit_scale, max=np.log(1. / 0.01)).exp()
         attn = attn * logit_scale
 
         relative_position_bias_table = self.cpb_mlp(


### PR DESCRIPTION
## Motivation

The original clamp operation is hard to read.

## Modification

Use `np.log` instead for better compatibilities for all pytorch version


## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
