### PR TITLE
[Enhancement] Get scores from inference api

### DIFF
--- a/docs/en/user_guides/inference.md
+++ b/docs/en/user_guides/inference.md
@@ -38,10 +38,10 @@ model = init_model(config_path, checkpoint_path, device="cpu")  # device can be 
 result = inference_model(model, img_path)
 ```
 
-`result` is a dictionary containing `pred_label`, `pred_score` and `pred_score`, the result is as follows:
+`result` is a dictionary containing `pred_label`, `pred_score`, `pred_scores` and `pred_class`, the result is as follows:
 
 ```text
-{"pred_label":65,"pred_score":0.6649366617202759,"pred_class":"sea snake"}
+{"pred_label":65,"pred_score":0.6649366617202759,"pred_class":"sea snake", "pred_scores": [..., 0.6649366617202759, ...]}
 ```
 
 An image demo can be found in [demo/image_demo.py](https://github.com/open-mmlab/mmclassification/blob/1.x/demo/image_demo.py).

--- a/docs/zh_CN/user_guides/inference.md
+++ b/docs/zh_CN/user_guides/inference.md
@@ -39,10 +39,10 @@ result = inference_model(model, img_path)
 print(result)
 ```
 
-`result` 为一个包含了 `pred_label`, `pred_score` 和 `pred_score`的字典，结果如下:
+`result` 为一个包含了 `pred_label`, `pred_score`, `pred_scores` 和 `pred_class`的字典，结果如下:
 
 ```text
-{"pred_label":65,"pred_score":0.6649366617202759,"pred_score":"sea snake"}
+{"pred_label":65,"pred_score":0.6649366617202759,"pred_class":"sea snake", "pred_scores": [..., 0.6649366617202759, ...]}
 ```
 
 演示可以在 [demo/image_demo.py](https://github.com/open-mmlab/mmclassification/blob/1.x/demo/image_demo.py) 中找到。

--- a/mmcls/apis/inference.py
+++ b/mmcls/apis/inference.py
@@ -80,9 +80,14 @@ def inference_model(model, img):
     # forward the model
     with torch.no_grad():
         prediction = model.val_step(data)[0].pred_label
+        pred_scores = prediction.score.tolist()
         pred_score = torch.max(prediction.score).item()
         pred_label = torch.argmax(prediction.score).item()
-        result = {'pred_label': pred_label, 'pred_score': float(pred_score)}
+        result = {
+            'pred_label': pred_label,
+            'pred_score': float(pred_score),
+            'pred_scores': pred_scores
+        }
     if hasattr(model, 'CLASSES'):
         result['pred_class'] = model.CLASSES[result['pred_label']]
     return result


### PR DESCRIPTION
## Motivation

Get pred_scores from inference api.

## Modification

```python
from mmcls.apis import inference_model, init_model
from mmcls.utils import register_all_modules

config_path = './configs/resnet/resnet50_8xb32_in1k.py'
checkpoint_path = 'https://download.openmmlab.com/mmclassification/v0/resnet/resnet50_8xb32_in1k_20210831-ea4938fc.pth' # can be a local path
img_path = 'demo/demo.JPEG'   # you can specify your own picture path

# register all modules and set mmcls as the default scope.
register_all_modules()
# build the model from a config file and a checkpoint file
model = init_model(config_path, checkpoint_path, device="cpu")  # device can be 'cuda:0'
# test a single image
result = inference_model(model, img_path)
```

`result` is a dictionary containing `pred_label`, `pred_score`, `pred_scores` and `pred_class`, the result is as follows:

```text
{"pred_label":65,"pred_score":0.6649366617202759,"pred_class":"sea snake", "pred_scores": [..., 0.6649366617202759, ...]}
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
