### PR TITLE
[Feature] Support mmcls with NPU backend.

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -128,14 +128,9 @@ def train_model(model,
         find_unused_parameters = cfg.get('find_unused_parameters', False)
         # Sets the `find_unused_parameters` parameter in
         # torch.nn.parallel.DistributedDataParallel
-        if cfg.device == 'npu':
-            current_device = torch.npu.current_device()
-        else:
-            current_device = torch.cuda.current_device()
         model = wrap_distributed_model(
             model,
             cfg.device,
-            device_ids=[current_device],
             broadcast_buffers=False,
             find_unused_parameters=find_unused_parameters)
     else:

--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -128,10 +128,14 @@ def train_model(model,
         find_unused_parameters = cfg.get('find_unused_parameters', False)
         # Sets the `find_unused_parameters` parameter in
         # torch.nn.parallel.DistributedDataParallel
+        if cfg.device == 'npu':
+            current_device = torch.npu.current_device()
+        else:
+            current_device = torch.cuda.current_device()
         model = wrap_distributed_model(
             model,
             cfg.device,
-            device_ids=[torch.cuda.current_device()],
+            device_ids=[current_device],
             broadcast_buffers=False,
             find_unused_parameters=find_unused_parameters)
     else:
@@ -173,6 +177,10 @@ def train_model(model,
 
     # fp16 setting
     fp16_cfg = cfg.get('fp16', None)
+
+    if fp16_cfg is None and device == 'npu':
+        fp16_cfg = {'loss_scale': 'dynamic'}
+
     if fp16_cfg is not None:
         if device == 'ipu':
             from mmcv.device.ipu import IPUFp16OptimizerHook

--- a/mmcls/datasets/samplers/distributed_sampler.py
+++ b/mmcls/datasets/samplers/distributed_sampler.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmcv.device.utils import IS_NPU_AVAILABLE
 from torch.utils.data import DistributedSampler as _DistributedSampler
 
 from mmcls.core.utils import sync_random_seed
@@ -30,7 +31,11 @@ class DistributedSampler(_DistributedSampler):
         # in the same order based on the same seed. Then different ranks
         # could use different indices to select non-overlapped data from the
         # same data list.
-        self.seed = sync_random_seed(seed)
+        if IS_NPU_AVAILABLE:
+            device = 'npu'
+        else:
+            device = 'cuda'
+        self.seed = sync_random_seed(seed, device)
 
     def __iter__(self):
         # deterministically shuffle based on epoch

--- a/mmcls/datasets/samplers/distributed_sampler.py
+++ b/mmcls/datasets/samplers/distributed_sampler.py
@@ -1,10 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
-from mmcv.device.utils import IS_NPU_AVAILABLE
 from torch.utils.data import DistributedSampler as _DistributedSampler
 
 from mmcls.core.utils import sync_random_seed
 from mmcls.datasets import SAMPLERS
+from mmcls.utils import auto_select_device
 
 
 @SAMPLERS.register_module()
@@ -31,11 +31,7 @@ class DistributedSampler(_DistributedSampler):
         # in the same order based on the same seed. Then different ranks
         # could use different indices to select non-overlapped data from the
         # same data list.
-        if IS_NPU_AVAILABLE:
-            device = 'npu'
-        else:
-            device = 'cuda'
-        self.seed = sync_random_seed(seed, device)
+        self.seed = sync_random_seed(seed, device=auto_select_device())
 
     def __iter__(self):
         # deterministically shuffle based on epoch

--- a/mmcls/utils/distribution.py
+++ b/mmcls/utils/distribution.py
@@ -16,7 +16,10 @@ def wrap_non_distributed_model(model, device='cuda', dim=0, *args, **kwargs):
     Returns:
         model(nn.Module): the model to be parallelized.
     """
-    if device == 'cuda':
+    if device == 'npu':
+        from mmcv.device.npu import NPUDataParallel
+        model = NPUDataParallel(model.npu(), dim=dim, *args, **kwargs)
+    elif device == 'cuda':
         from mmcv.parallel import MMDataParallel
         model = MMDataParallel(model.cuda(), dim=dim, *args, **kwargs)
     elif device == 'cpu':
@@ -49,7 +52,10 @@ def wrap_distributed_model(model, device='cuda', *args, **kwargs):
         .. [1] https://pytorch.org/docs/stable/generated/torch.nn.parallel.
                DistributedDataParallel.html
     """
-    if device == 'cuda':
+    if device == 'npu':
+        from mmcv.device.npu import NPUDistributedDataParallel
+        model = NPUDistributedDataParallel(model.npu(), *args, **kwargs)
+    elif device == 'cuda':
         from mmcv.parallel import MMDistributedDataParallel
         model = MMDistributedDataParallel(model.cuda(), *args, **kwargs)
     else:

--- a/mmcls/utils/distribution.py
+++ b/mmcls/utils/distribution.py
@@ -54,10 +54,14 @@ def wrap_distributed_model(model, device='cuda', *args, **kwargs):
     """
     if device == 'npu':
         from mmcv.device.npu import NPUDistributedDataParallel
-        model = NPUDistributedDataParallel(model.npu(), *args, **kwargs)
+        from torch.npu import current_device
+        model = NPUDistributedDataParallel(
+            model.npu(), *args, device_ids=[current_device()], **kwargs)
     elif device == 'cuda':
         from mmcv.parallel import MMDistributedDataParallel
-        model = MMDistributedDataParallel(model.cuda(), *args, **kwargs)
+        from torch.cuda import current_device
+        model = MMDistributedDataParallel(
+            model.cuda(), *args, device_ids=[current_device()], **kwargs)
     else:
         raise RuntimeError(f'Unavailable device "{device}"')
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Added ascending device support in mmcv.

## Modification

- The main modification points are as follows: 
    1. In ```mmcls/apis/train.py```, We added an NPU device in the DDP scenario, and the mixing accuracy is enabled by default when using the NPU
    2. In ``mmcls/utils/distribution.py```, We have added DP and DDP classes for NPU
    3. In ``mmcls/datasets/samplers/distributed_sampler.py```, We added device judgment to make the broadcast within the sync_random_seed function execute correctly on the npu

## BC-breaking (Optional)

A new mmcv containing the NPU background needed.

## Use cases (Optional)

We tested [resnet50_8xb32_in1k.py](https://github.com/open-mmlab/mmclassification/blob/master/configs/resnet/resnet50_8xb32_in1k.py) with ```Top-1 (%): 76.4```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
