### PR TITLE
[Docs] Support sort and search the Model Summary table.

### DIFF
--- a/docs/en/_static/js/custom.js
+++ b/docs/en/_static/js/custom.js
@@ -1,1 +1,10 @@
 var collapsedSections = ['Model zoo'];
+
+$(document).ready(function () {
+  $('.model-summary').DataTable({
+    "stateSave": false,
+    "lengthChange": false,
+    "pageLength": 20,
+    "order": []
+  });
+});

--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -125,8 +125,14 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-html_css_files = ['css/readthedocs.css']
-html_js_files = ['js/custom.js']
+html_css_files = [
+    'https://cdn.datatables.net/v/bs4/dt-1.12.1/datatables.min.css',
+    'css/readthedocs.css'
+]
+html_js_files = [
+    'https://cdn.datatables.net/v/bs4/dt-1.12.1/datatables.min.js',
+    'js/custom.js'
+]
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/en/stat.py
+++ b/docs/en/stat.py
@@ -12,12 +12,20 @@ GITHUB_PREFIX = 'https://github.com/open-mmlab/mmclassification/blob/1.x/'
 MODELZOO_TEMPLATE = """
 # Model Zoo Summary
 
+In this page, we list [all algorithms](#all-supported-algorithms) we support. You can click the link to jump to the corresponding model pages.
+
+And we also list [all checkpoints](#all-checkpoints) we provide on various datasets. You can sort or search the table and use the link to jump to the model pages.
+
+## All supported algorithms
+
 * Number of papers: {num_papers}
 {type_msg}
 
 * Number of checkpoints: {num_ckpts}
 {paper_msg}
-"""
+
+## All checkpoints
+"""  # noqa: E501
 
 model_index = load(str(MMCLS_ROOT / 'model-index.yml'))
 
@@ -123,7 +131,7 @@ def generate_summary_table(models):
 
     with open('modelzoo_statistics.md', 'a') as f:
         for dataset, rows in dataset_rows.items():
-            f.write(f'\n## {dataset}\n')
+            f.write(f'\n### {dataset}\n')
             f.write("""```{table}\n:class: model-summary\n""")
             header = [
                 'Model',

--- a/docs/en/stat.py
+++ b/docs/en/stat.py
@@ -14,7 +14,7 @@ MODELZOO_TEMPLATE = """
 
 In this page, we list [all algorithms](#all-supported-algorithms) we support. You can click the link to jump to the corresponding model pages.
 
-And we also list [all checkpoints](#all-checkpoints) we provide on various datasets. You can sort or search the table and use the link to jump to the model pages.
+And we also list [all checkpoints](#all-checkpoints) we provide. You can sort or search checkpoints in the table and click the corresponding link to model pages for more details.
 
 ## All supported algorithms
 

--- a/docs/zh_CN/_static/js/custom.js
+++ b/docs/zh_CN/_static/js/custom.js
@@ -1,1 +1,20 @@
 var collapsedSections = ['Model zoo'];
+
+$(document).ready(function () {
+  $('.model-summary').DataTable({
+    "stateSave": false,
+    "lengthChange": false,
+    "pageLength": 20,
+    "order": [],
+    "language": {
+      "info": "显示 _START_ 至 _END_ 条目（总计 _TOTAL_ ）",
+      "infoFiltered": "（筛选自 _MAX_ 条目）",
+      "search": "搜索：",
+      "zeroRecords": "没有找到任何条目",
+      "paginate": {
+        "next": "下一页",
+        "previous": "上一页"
+      },
+    }
+  });
+});

--- a/docs/zh_CN/conf.py
+++ b/docs/zh_CN/conf.py
@@ -125,8 +125,14 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-html_css_files = ['css/readthedocs.css']
-html_js_files = ['js/custom.js']
+html_css_files = [
+    'https://cdn.datatables.net/v/bs4/dt-1.12.1/datatables.min.css',
+    'css/readthedocs.css'
+]
+html_js_files = [
+    'https://cdn.datatables.net/v/bs4/dt-1.12.1/datatables.min.js',
+    'js/custom.js'
+]
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/zh_CN/stat.py
+++ b/docs/zh_CN/stat.py
@@ -12,12 +12,20 @@ GITHUB_PREFIX = 'https://github.com/open-mmlab/mmclassification/blob/1.x/'
 MODELZOO_TEMPLATE = """
 # 模型库统计
 
+在本页面中，我们列举了我们支持的[所有算法](#所有已支持的算法)。你可以点击链接跳转至对应的模型详情页面。
+
+另外，我们还列出了我们提供的[所有模型权重文件](#所有模型权重文件)。你可以使用排序和搜索功能找到需要的模型权重，并使用链接跳转至模型详情页面。
+
+## 所有已支持的算法
+
 * 论文数量：{num_papers}
 {type_msg}
 
 * 模型权重文件数量：{num_ckpts}
 {paper_msg}
-"""
+
+## 所有模型权重文件
+"""  # noqa: E501
 
 model_index = load(str(MMCLS_ROOT / 'model-index.yml'))
 
@@ -123,7 +131,7 @@ def generate_summary_table(models):
 
     with open('modelzoo_statistics.md', 'a') as f:
         for dataset, rows in dataset_rows.items():
-            f.write(f'\n## {dataset}\n')
+            f.write(f'\n### {dataset}\n')
             f.write("""```{table}\n:class: model-summary\n""")
             header = [
                 '模型',


### PR DESCRIPTION
Use the [datatable](https://datatables.net/) package to enable sorting and searching the model summary table in the docs.

![image](https://user-images.githubusercontent.com/26739999/196385295-b10ead0c-39da-48bf-9cc7-27049f39a518.png)
