### PR TITLE
[Feature] Support TTA and add `--tta` in `tools/test.py`.

### DIFF
--- a/mmcls/models/__init__.py
+++ b/mmcls/models/__init__.py
@@ -8,6 +8,7 @@ from .heads import *  # noqa: F401,F403
 from .losses import *  # noqa: F401,F403
 from .necks import *  # noqa: F401,F403
 from .retrievers import *  # noqa: F401,F403
+from .tta import *  # noqa: F401,F403
 from .utils import *  # noqa: F401,F403
 
 __all__ = [

--- a/mmcls/models/tta/__init__.py
+++ b/mmcls/models/tta/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .score_tta import AverageScoreTTAModel
+from .score_tta import AverageClsScoreTTA
 
-__all__ = ['AverageScoreTTAModel']
+__all__ = ['AverageClsScoreTTA']

--- a/mmcls/models/tta/__init__.py
+++ b/mmcls/models/tta/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .score_tta import AverageScoreTTAModel
+
+__all__ = ['AverageScoreTTAModel']

--- a/mmcls/models/tta/score_tta.py
+++ b/mmcls/models/tta/score_tta.py
@@ -2,25 +2,33 @@
 from typing import List
 
 from mmengine.model import BaseTTAModel
-from mmengine.structures import BaseDataElement
 
 from mmcls.registry import MODELS
 from mmcls.structures import ClsDataSample
 
 
 @MODELS.register_module()
-class AverageScoreTTAModel(BaseTTAModel):
+class AverageClsScoreTTA(BaseTTAModel):
 
     def merge_preds(
         self,
         data_samples_list: List[List[ClsDataSample]],
-    ) -> List[BaseDataElement]:
+    ) -> List[ClsDataSample]:
+        """Merge predictions of enhanced data to one prediction.
+
+        Args:
+            data_samples_list (List[List[ClsDataSample]]): List of predictions
+                of all enhanced data.
+
+        Returns:
+            List[ClsDataSample]: Merged prediction.
+        """
         merged_data_samples = []
         for data_samples in data_samples_list:
-            merged_data_samples.append(self.merge_single_sample(data_samples))
+            merged_data_samples.append(self._merge_single_sample(data_samples))
         return merged_data_samples
 
-    def merge_single_sample(self, data_samples):
+    def _merge_single_sample(self, data_samples):
         merged_data_sample: ClsDataSample = data_samples[0].new()
         merged_score = sum(data_sample.pred_label.score
                            for data_sample in data_samples) / len(data_samples)

--- a/mmcls/models/tta/score_tta.py
+++ b/mmcls/models/tta/score_tta.py
@@ -1,0 +1,28 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import List
+
+from mmengine.model import BaseTTAModel
+from mmengine.structures import BaseDataElement
+
+from mmcls.registry import MODELS
+from mmcls.structures import ClsDataSample
+
+
+@MODELS.register_module()
+class AverageScoreTTAModel(BaseTTAModel):
+
+    def merge_preds(
+        self,
+        data_samples_list: List[List[ClsDataSample]],
+    ) -> List[BaseDataElement]:
+        merged_data_samples = []
+        for data_samples in data_samples_list:
+            merged_data_samples.append(self.merge_single_sample(data_samples))
+        return merged_data_samples
+
+    def merge_single_sample(self, data_samples):
+        merged_data_sample: ClsDataSample = data_samples[0].new()
+        merged_score = sum(data_sample.pred_label.score
+                           for data_sample in data_samples) / len(data_samples)
+        merged_data_sample.set_pred_score(merged_score)
+        return merged_data_sample

--- a/tests/test_models/test_tta.py
+++ b/tests/test_models/test_tta.py
@@ -1,0 +1,67 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from copy import deepcopy
+from unittest import TestCase
+
+import torch
+from mmengine import ConfigDict
+
+from mmcls.models import AverageScoreTTAModel, ImageClassifier
+from mmcls.registry import MODELS
+from mmcls.structures import ClsDataSample
+from mmcls.utils import register_all_modules
+
+register_all_modules()
+
+
+class TestAverageScoreTTAModel(TestCase):
+    DEFAULT_ARGS = dict(
+        type='AverageScoreTTAModel',
+        module=dict(
+            type='ImageClassifier',
+            backbone=dict(type='ResNet', depth=18),
+            neck=dict(type='GlobalAveragePooling'),
+            head=dict(
+                type='LinearClsHead',
+                num_classes=10,
+                in_channels=512,
+                loss=dict(type='CrossEntropyLoss'))))
+
+    def test_initialize(self):
+        model: AverageScoreTTAModel = MODELS.build(self.DEFAULT_ARGS)
+        self.assertIsInstance(model.module, ImageClassifier)
+
+    def test_forward(self):
+        inputs = torch.rand(1, 3, 224, 224)
+        model: AverageScoreTTAModel = MODELS.build(self.DEFAULT_ARGS)
+
+        # The forward of TTA model should not be called.
+        with self.assertRaisesRegex(NotImplementedError, 'will not be called'):
+            model(inputs)
+
+    def test_test_step(self):
+        cfg = ConfigDict(deepcopy(self.DEFAULT_ARGS))
+        cfg.module.data_preprocessor = dict(
+            mean=[127.5, 127.5, 127.5], std=[127.5, 127.5, 127.5])
+        model: AverageScoreTTAModel = MODELS.build(cfg)
+
+        img1 = torch.randint(0, 256, (1, 3, 224, 224))
+        img2 = torch.randint(0, 256, (1, 3, 224, 224))
+        data1 = {
+            'inputs': img1,
+            'data_samples': [ClsDataSample().set_gt_label(1)]
+        }
+        data2 = {
+            'inputs': img2,
+            'data_samples': [ClsDataSample().set_gt_label(1)]
+        }
+        data_tta = {
+            'inputs': [img1, img2],
+            'data_samples': [[ClsDataSample().set_gt_label(1)],
+                             [ClsDataSample().set_gt_label(1)]]
+        }
+
+        score1 = model.module.test_step(data1)[0].pred_label.score
+        score2 = model.module.test_step(data2)[0].pred_label.score
+        score_tta = model.test_step(data_tta)[0].pred_label.score
+
+        torch.testing.assert_allclose(score_tta, (score1 + score2) / 2)

--- a/tests/test_models/test_tta.py
+++ b/tests/test_models/test_tta.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import torch
 from mmengine import ConfigDict
 
-from mmcls.models import AverageScoreTTAModel, ImageClassifier
+from mmcls.models import AverageClsScoreTTA, ImageClassifier
 from mmcls.registry import MODELS
 from mmcls.structures import ClsDataSample
 from mmcls.utils import register_all_modules
@@ -13,9 +13,9 @@ from mmcls.utils import register_all_modules
 register_all_modules()
 
 
-class TestAverageScoreTTAModel(TestCase):
+class TestAverageClsScoreTTA(TestCase):
     DEFAULT_ARGS = dict(
-        type='AverageScoreTTAModel',
+        type='AverageClsScoreTTA',
         module=dict(
             type='ImageClassifier',
             backbone=dict(type='ResNet', depth=18),
@@ -27,12 +27,12 @@ class TestAverageScoreTTAModel(TestCase):
                 loss=dict(type='CrossEntropyLoss'))))
 
     def test_initialize(self):
-        model: AverageScoreTTAModel = MODELS.build(self.DEFAULT_ARGS)
+        model: AverageClsScoreTTA = MODELS.build(self.DEFAULT_ARGS)
         self.assertIsInstance(model.module, ImageClassifier)
 
     def test_forward(self):
         inputs = torch.rand(1, 3, 224, 224)
-        model: AverageScoreTTAModel = MODELS.build(self.DEFAULT_ARGS)
+        model: AverageClsScoreTTA = MODELS.build(self.DEFAULT_ARGS)
 
         # The forward of TTA model should not be called.
         with self.assertRaisesRegex(NotImplementedError, 'will not be called'):
@@ -42,7 +42,7 @@ class TestAverageScoreTTAModel(TestCase):
         cfg = ConfigDict(deepcopy(self.DEFAULT_ARGS))
         cfg.module.data_preprocessor = dict(
             mean=[127.5, 127.5, 127.5], std=[127.5, 127.5, 127.5])
-        model: AverageScoreTTAModel = MODELS.build(cfg)
+        model: AverageClsScoreTTA = MODELS.build(cfg)
 
         img1 = torch.randint(0, 256, (1, 3, 224, 224))
         img2 = torch.randint(0, 256, (1, 3, 224, 224))

--- a/tools/test.py
+++ b/tools/test.py
@@ -115,7 +115,7 @@ def merge_args(cfg, args):
     # -------------------- TTA related args --------------------
     if args.tta:
         if 'tta_model' not in cfg:
-            cfg.tta_model = dict(type='mmcls.AverageScoreTTAModel')
+            cfg.tta_model = dict(type='mmcls.AverageClsScoreTTA')
         if 'tta_pipeline' not in cfg:
             test_pipeline = cfg.test_dataloader.dataset.pipeline
             cfg.tta_pipeline = deepcopy(test_pipeline)


### PR DESCRIPTION
## Motivation

To support Test-Time-Aug (TTA).

## Modification

- Add `AverageScoreTTAModel` inherited from the `BaseTTAModel` in MMEngine.
- Add `--tta` option in `tools/test.py` to enable TTA during the test.

## Use cases

**To use the default TTA (average the classification scores of images w/ and w/o flip)**
```bash
python tools/test.py configs/resnet/resnet50_8xb32_in1k.py checkpoints/resnet50_in1k.pth --tta
```

**To use your own custom TTA method**
1. Add `tta_model` and `tta_pipeline` in your config file:
```python
...
tta_model = dict(type='AverageScoreTTAModel')
tta_pipeline = [
    dict(type='LoadImageFromFile'),
    dict(type='ResizeEdge', scale=384, edge='short'),
    dict(type='CenterCrop', crop_size=384),
    dict(type='TestTimeAug',
         transforms=[
             [
                 dict(type='Resize', scale=224),
                 dict(type='Resize', scale=384)
             ],
             [
                 dict(type='RandomFlip', prob=1.),
                 dict(type='RandomFlip', prob=0.)
             ],
             [dict(type='PackClsInputs')],
         ]),
]
```
2. test with TTA
```bash
python tools/test.py configs/resnet/resnet50_8xb32_in1k.py checkpoints/resnet50_in1k.pth --tta
```
## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
