### PR TITLE
[Fix] adapt to matplotlib fig 1px precision lost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,28 +188,9 @@ workflows:
             requires:
               - lint
         - build:
-            name: build_py36_torch1.6
-            torch: 1.6.0
-            torchvision: 0.7.0
-            requires:
-              - lint
-        - build:
             name: build_py36_torch1.7
             torch: 1.7.0
             torchvision: 0.8.1
-            requires:
-              - lint
-        - build:
-            name: build_py36_torch1.8
-            torch: 1.8.0
-            torchvision: 0.9.0
-            requires:
-              - lint
-        - build:
-            name: build_py39_torch1.8
-            torch: 1.8.0
-            torchvision: 0.9.0
-            python: "3.9.0"
             requires:
               - lint
         - build:
@@ -219,21 +200,10 @@ workflows:
             python: "3.9.0"
             requires:
               - lint
-        - build:
-            name: build_py39_torch1.10
-            torch: 1.10.0
-            torchvision: 0.11.1
-            python: "3.9.0"
-            requires:
-              - lint
         - build_with_cuda:
             name: build_py36_torch1.6_cu101
             requires:
               - build_with_timm
               - build_py36_torch1.5
-              - build_py36_torch1.6
               - build_py36_torch1.7
-              - build_py36_torch1.8
-              - build_py39_torch1.8
               - build_py39_torch1.9
-              - build_py39_torch1.10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       UBUNTU_VERSION: ubuntu1804
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
         torch: [1.8.0]
         include:
           - torch: 1.8.0
@@ -84,43 +84,24 @@ jobs:
       UBUNTU_VERSION: ubuntu1804
     strategy:
       matrix:
-        python-version: [3.7]
-        torch: [1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
+        torch: [1.5.0, 1.8.0, 1.10.0, 1.13.0]
         include:
           - torch: 1.5.0
             torchvision: 0.6.0
             torch_major: 1.5.0
-          - torch: 1.6.0
-            torchvision: 0.7.0
-            torch_major: 1.6.0
-          - torch: 1.7.0
-            torchvision: 0.8.1
-            torch_major: 1.7.0
+            python-version: '3.7'
           - torch: 1.8.0
             torchvision: 0.9.0
             torch_major: 1.8.0
-          - torch: 1.8.0
-            torchvision: 0.9.0
-            torch_major: 1.8.0
-            python-version: 3.8
-          - torch: 1.8.0
-            torchvision: 0.9.0
-            torch_major: 1.8.0
-            python-version: 3.9
-          - torch: 1.9.0
-            torchvision: 0.10.0
-            torch_major: 1.9.0
+            python-version: '3.8'
           - torch: 1.10.0
             torchvision: 0.11.1
             torch_major: 1.10.0
-          - torch: 1.10.0
-            torchvision: 0.11.1
-            torch_major: 1.10.0
-            python-version: 3.8
-          - torch: 1.10.0
-            torchvision: 0.11.1
-            torch_major: 1.10.0
-            python-version: 3.9
+            python-version: '3.9'
+          - torch: 1.13.0
+            torchvision: 0.14.0
+            torch_major: 1.13.0
+            python-version: '3.10'
 
     steps:
       - uses: actions/checkout@v2

--- a/.owners.yml
+++ b/.owners.yml
@@ -1,0 +1,18 @@
+# assign issues to owners automatically
+assign:
+  issues: enabled # or disabled
+  pull_requests: enabled # or disabled
+  # assign strategy, both issues and pull requests follow the same strategy
+  strategy:
+    # random
+    # round-robin
+    daily-shift-based
+  schedule:
+    '*/1 * * * *'
+  # assignees
+  assignees:
+    - mzr1996
+    - tonysy
+    - Ezra-Yu
+    - techmonsterwang
+    - yingfhu

--- a/mmcls/core/visualization/image.py
+++ b/mmcls/core/visualization/image.py
@@ -4,6 +4,9 @@ import mmcv
 import numpy as np
 from matplotlib.backend_bases import CloseEvent
 
+# A small value
+EPS = 1e-2
+
 
 def color_val_matplotlib(color):
     """Convert various input in BGR order to normalized RGB matplotlib color
@@ -244,10 +247,11 @@ class ImshowInfosContextManager(BaseFigureContextManager):
         width, height = img.shape[1], img.shape[0]
         img = np.ascontiguousarray(img)
 
-        # there might be a 1px precision lost due to matplotlib's
+        # add a small EPS to avoid precision lost due to matplotlib's
         # truncation (https://github.com/matplotlib/matplotlib/issues/15363)
         dpi = self.fig_save.get_dpi()
-        self.fig_save.set_size_inches(width / dpi, height / dpi)
+        self.fig_save.set_size_inches((width + EPS) / dpi,
+                                      (height + EPS) / dpi)
 
         for k, v in infos.items():
             if isinstance(v, float):
@@ -261,13 +265,13 @@ class ImshowInfosContextManager(BaseFigureContextManager):
             y += row_width
 
         self.ax_save.imshow(img)
-        stream, _ = self.fig_save.canvas.print_to_buffer()
+        stream, (buffer_w, buffer_h) = self.fig_save.canvas.print_to_buffer()
         buffer = np.frombuffer(stream, dtype='uint8')
 
-        # for 1px precision lost, we don't use origin height and width
-        # to reshape the buffer instead we use the figure bbox height and width
-        img_rgba = buffer.reshape(
-            int(self.fig_save.bbox.height), int(self.fig_save.bbox.width), 4)
+        # The `EPS` won't solve all precision lost problems, therefore we don't
+        # use origin height and width to reshape the buffer but use the buffer
+        # shape. These may cause shape difference between the input and output.
+        img_rgba = buffer.reshape(buffer_h, buffer_w, 4)
 
         rgb, _ = np.split(img_rgba, [3], axis=2)
         img_save = rgb.astype('uint8')


### PR DESCRIPTION
## Motivation

on my m1 mac, when I run example https://github.com/wangruohui/sjtu-openmmlab-tutorial/blob/main/cls-2-train.ipynb

encounter error is that

```
Traceback (most recent call last):
  File "cls-1-inference.py", line 72, in <module>
    show_result_pyplot(model, 'banana.png', result)
  File "/Users/zoupeng/miniconda3/envs/openmmlab/lib/python3.8/site-packages/mmcls/apis/inference.py", line 114, in show_result_pyplot
    model.show_result(
  File "/Users/zoupeng/miniconda3/envs/openmmlab/lib/python3.8/site-packages/mmcls/models/classifiers/base.py", line 212, in show_result
    img = imshow_infos(
  File "/Users/zoupeng/miniconda3/envs/openmmlab/lib/python3.8/site-packages/mmcls/core/visualization/image.py", line 333, in imshow_infos
    _, img = manager.put_img_infos(
  File "/Users/zoupeng/miniconda3/envs/openmmlab/lib/python3.8/site-packages/mmcls/core/visualization/image.py", line 270, in put_img_infos
    img_rgba = buffer.reshape(height, width, 4)
ValueError: cannot reshape array of size 630336 into shape (403,393,4)
```

origin image is `403 * 393`, but buffer 630336 shape would be `402 * 392 * 4`, 1 px precision lost occurs.

I found it's still 1 px precision lost after add EPS(0.01) after execute https://github.com/open-mmlab/mmclassification/blob/48fdcdbf76907f72a5aa167df94a618154783694/mmcls/core/visualization/image.py#L253

in https://github.com/matplotlib/matplotlib/issues/15363 discussions, it seems inevitable.

Can we make the `buffer.reshape` adapt to 1px precision?

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
