### PR TITLE
[Fix] Fix the requirements and lazy register mmcls models.

### DIFF
--- a/mmcls/apis/inference.py
+++ b/mmcls/apis/inference.py
@@ -1,16 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 import torch
-from mmengine.dataset import Compose, default_collate
-from mmengine.model import BaseModel
-from mmengine.registry import DefaultScope
 
-import mmcls.datasets  # noqa: F401
+if TYPE_CHECKING:
+    from mmengine.model import BaseModel
 
 
-def inference_model(model: BaseModel, img: Union[str, np.ndarray]):
+def inference_model(model: 'BaseModel', img: Union[str, np.ndarray]):
     """Inference image(s) with the classifier.
 
     Args:
@@ -21,6 +19,11 @@ def inference_model(model: BaseModel, img: Union[str, np.ndarray]):
         result (dict): The classification results that contains
             `class_name`, `pred_label` and `pred_score`.
     """
+    from mmengine.dataset import Compose, default_collate
+    from mmengine.registry import DefaultScope
+
+    import mmcls.datasets  # noqa: F401
+
     cfg = model.cfg
     # build the data pipeline
     test_pipeline_cfg = cfg.test_dataloader.dataset.pipeline

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,5 @@
 matplotlib
+modelindex
 numpy
 packaging
 rich


### PR DESCRIPTION
## Motivation

The `modelindex` package is missing in the requirements.

## Modification

- Add it in the `requirements/runtime.txt.`
- In the `mmcls.apis` package, avoid importing some packages and registering mmcls models directly. This modification can speed up `import mmcls` (from ~3.2s to ~0.7s)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
