### PR TITLE
[Bug] Revise the _remove_state_dict_prefix and _add_state_dict_prefix functions in timm.py to adapt to the case of multiple submodels.

### DIFF
--- a/mmcls/models/classifiers/timm.py
+++ b/mmcls/models/classifiers/timm.py
@@ -190,12 +190,17 @@ class TimmClassifier(BaseClassifier):
         return data_samples
 
     @staticmethod
-    def _remove_state_dict_prefix(self, state_dict, prefix, local_metadata):
-        new_state_dict = OrderedDict()
-        for k, v in state_dict.items():
+    def _remove_state_dict_prefix(module, state_dict, prefix, local_metadata):
+        for k in list(state_dict.keys()):
             new_key = re.sub(f'^{prefix}model.', prefix, k)
-            new_state_dict[new_key] = v
-        return new_state_dict
+            # Only delete the key that different from its new_key
+            if new_key != k:
+                # Modify the `state_dict` directly to avoid invalid changes
+                # when recursively calling the `state_dict` function in
+                # `torch.nn.module`.
+                state_dict[new_key] = state_dict[k]
+                del state_dict[k]
+        return state_dict
 
     @staticmethod
     def _add_state_dict_prefix(state_dict, prefix, local_metadata, strict,
@@ -203,5 +208,7 @@ class TimmClassifier(BaseClassifier):
         new_prefix = prefix + 'model.'
         for k in list(state_dict.keys()):
             new_key = re.sub(f'^{prefix}', new_prefix, k)
-            state_dict[new_key] = state_dict[k]
-            del state_dict[k]
+            # Only delete the key that different from its new_key
+            if new_key != k:
+                state_dict[new_key] = state_dict[k]
+                del state_dict[k]


### PR DESCRIPTION
When using `TimmClassifier` as student or teacher model in Knowledge Distillation Algorithms, there have some bugs in `save_checkpoint` and `load_checkpoint`.

1. save_checkpoint
When saving checkpoint like `save_checkpoint(self.state_dict(), 'xxx.pth')`, where `self` is a Knowledge Distillation Algorithm which contains submodels `self.student` and `self.teacher`, `self.state_dict()` will recursively call the [state_dict](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L1725) function [here](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L1793-L1795).
The `_remove_state_dict_prefix` function in the `TimmClassifier` class will be used as a hook to [modify the original `destination`](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L1796-L1799).
Specifically, the `_remove_state_dict_prefix` function creates a `new_state_dict` whose memory is different from the original `destination` as the `hook_result` to [modify the original `destination`](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L1796-L1799) for submodels `student` and `teacher`. But the state_dict funtion of the Knowledge Distillation Algorithm Model will [not receive this modify](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L1795), so the memory address and value of `destination` have not changed.
To solve this problem, we change the `_remove_state_dict_prefix` function to modify the `state_dict` directly instead of creating a `new_state_dict`.
    
2. load_checkpoint
When loading checkpoint of a Knowledge Distillation Algorithm Model whose student and teacher are all `TimmClassifier`. The `_add_state_dict_prefix` function in the `TimmClassifier` class will be used as a hook to modify the `state_dict` of each submodel.
When modifying the student submodel, `_add_state_dict_prefix` function will delete all keys of `teacher` submodel.
To solve this problem, we change the `_add_state_dict_prefix` function to only delete the key that different from its new_key.
