### PR TITLE
[WIP] add OpenAI's CLIP weights

### DIFF
--- a/configs/_base_/datasets/imagenet_bs64_clip_224.py
+++ b/configs/_base_/datasets/imagenet_bs64_clip_224.py
@@ -1,72 +1,74 @@
 # dataset settings
 dataset_type = 'ImageNet'
-img_norm_cfg = dict(
+data_preprocessor = dict(
+    num_classes=1000,
+    # RGB format normalization parameters
     mean=[0.48145466 * 255, 0.4578275 * 255, 0.40821073 * 255],
     std=[0.26862954 * 255, 0.26130258 * 255, 0.27577711 * 255],
-    to_rgb=True)
+    # convert image from BGR to RGB
+    to_rgb=True,
+)
 image_size = 224
+
+bgr_mean = data_preprocessor['mean'][::-1]
+bgr_std = data_preprocessor['std'][::-1]
+
 train_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(
         type='RandomResizedCrop',
-        size=image_size,
+        scale=image_size,
         backend='pillow',
         interpolation='bicubic'),
-    dict(type='RandomFlip', flip_prob=0.5, direction='horizontal'),
-    # dict(
-    #     type='RandAugment',
-    #     policies={{_base_.rand_increasing_policies}},
-    #     num_policies=2,
-    #     total_level=10,
-    #     magnitude_level=9,
-    #     magnitude_std=0.5,
-    #     hparams=dict(
-    #         pad_val=[round(x) for x in img_norm_cfg['mean'][::-1]],
-    #         interpolation='bicubic')),
+    dict(type='RandomFlip', prob=0.5, direction='horizontal'),
     dict(
         type='RandomErasing',
         erase_prob=0.25,
-        mode='rand',
+        mode='rand',  # should be 'pixel', but currently not supported
         min_area_ratio=0.02,
         max_area_ratio=1 / 3,
-        fill_color=img_norm_cfg['mean'][::-1],
-        fill_std=img_norm_cfg['std'][::-1]),
-    dict(type='Normalize', **img_norm_cfg),
-    dict(type='ImageToTensor', keys=['img']),
-    dict(type='ToTensor', keys=['gt_label']),
-    dict(type='Collect', keys=['img', 'gt_label'])
+        fill_color=bgr_mean,
+        fill_std=bgr_std),
+    dict(type='PackClsInputs'),
 ]
 
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(
-        type='Resize',
-        size=(image_size, -1),
+        type='ResizeEdge',
+        scale=image_size,
+        edge='short',
         backend='pillow',
         interpolation='bicubic'),
     dict(type='CenterCrop', crop_size=image_size),
-    dict(type='Normalize', **img_norm_cfg),
-    dict(type='ImageToTensor', keys=['img']),
-    dict(type='Collect', keys=['img'])
+    dict(type='PackClsInputs'),
 ]
 
-data = dict(
-    samples_per_gpu=64,
-    workers_per_gpu=8,
-    train=dict(
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=8,
+    dataset=dict(
         type=dataset_type,
-        data_prefix='data/imagenet/train',
+        data_root='data/imagenet',
+        ann_file='meta/train.txt',
+        data_prefix='train',
         pipeline=train_pipeline),
-    val=dict(
-        type=dataset_type,
-        data_prefix='data/imagenet/val',
-        ann_file='data/imagenet/meta/val.txt',
-        pipeline=test_pipeline),
-    test=dict(
-        # replace `data/val` with `data/test` for standard test
-        type=dataset_type,
-        data_prefix='data/imagenet/val',
-        ann_file='data/imagenet/meta/val.txt',
-        pipeline=test_pipeline))
+    sampler=dict(type='DefaultSampler', shuffle=True),
+)
 
-evaluation = dict(interval=10, metric='accuracy')
+val_dataloader = dict(
+    batch_size=64,
+    num_workers=8,
+    dataset=dict(
+        type=dataset_type,
+        data_root='data/imagenet',
+        ann_file='meta/val.txt',
+        data_prefix='val',
+        pipeline=test_pipeline),
+    sampler=dict(type='DefaultSampler', shuffle=False),
+)
+val_evaluator = dict(type='Accuracy', topk=(1, 5))
+
+# If you want standard test, please manually configure the test dataset
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator

--- a/configs/_base_/datasets/imagenet_bs64_clip_336.py
+++ b/configs/_base_/datasets/imagenet_bs64_clip_336.py
@@ -8,7 +8,7 @@ data_preprocessor = dict(
     # convert image from BGR to RGB
     to_rgb=True,
 )
-image_size = 448
+image_size = 336
 
 bgr_mean = data_preprocessor['mean'][::-1]
 bgr_std = data_preprocessor['std'][::-1]

--- a/configs/_base_/datasets/imagenet_bs64_clip_384.py
+++ b/configs/_base_/datasets/imagenet_bs64_clip_384.py
@@ -1,72 +1,74 @@
 # dataset settings
 dataset_type = 'ImageNet'
-img_norm_cfg = dict(
+data_preprocessor = dict(
+    num_classes=1000,
+    # RGB format normalization parameters
     mean=[0.48145466 * 255, 0.4578275 * 255, 0.40821073 * 255],
     std=[0.26862954 * 255, 0.26130258 * 255, 0.27577711 * 255],
-    to_rgb=True)
+    # convert image from BGR to RGB
+    to_rgb=True,
+)
 image_size = 384
+
+bgr_mean = data_preprocessor['mean'][::-1]
+bgr_std = data_preprocessor['std'][::-1]
+
 train_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(
         type='RandomResizedCrop',
-        size=image_size,
+        scale=image_size,
         backend='pillow',
         interpolation='bicubic'),
-    dict(type='RandomFlip', flip_prob=0.5, direction='horizontal'),
-    # dict(
-    #     type='RandAugment',
-    #     policies={{_base_.rand_increasing_policies}},
-    #     num_policies=2,
-    #     total_level=10,
-    #     magnitude_level=9,
-    #     magnitude_std=0.5,
-    #     hparams=dict(
-    #         pad_val=[round(x) for x in img_norm_cfg['mean'][::-1]],
-    #         interpolation='bicubic')),
+    dict(type='RandomFlip', prob=0.5, direction='horizontal'),
     dict(
         type='RandomErasing',
         erase_prob=0.25,
-        mode='rand',
+        mode='rand',  # should be 'pixel', but currently not supported
         min_area_ratio=0.02,
         max_area_ratio=1 / 3,
-        fill_color=img_norm_cfg['mean'][::-1],
-        fill_std=img_norm_cfg['std'][::-1]),
-    dict(type='Normalize', **img_norm_cfg),
-    dict(type='ImageToTensor', keys=['img']),
-    dict(type='ToTensor', keys=['gt_label']),
-    dict(type='Collect', keys=['img', 'gt_label'])
+        fill_color=bgr_mean,
+        fill_std=bgr_std),
+    dict(type='PackClsInputs'),
 ]
 
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(
-        type='Resize',
-        size=(image_size, -1),
+        type='ResizeEdge',
+        scale=image_size,
+        edge='short',
         backend='pillow',
         interpolation='bicubic'),
     dict(type='CenterCrop', crop_size=image_size),
-    dict(type='Normalize', **img_norm_cfg),
-    dict(type='ImageToTensor', keys=['img']),
-    dict(type='Collect', keys=['img'])
+    dict(type='PackClsInputs'),
 ]
 
-data = dict(
-    samples_per_gpu=64,
-    workers_per_gpu=8,
-    train=dict(
+train_dataloader = dict(
+    batch_size=64,
+    num_workers=8,
+    dataset=dict(
         type=dataset_type,
-        data_prefix='data/imagenet/train',
+        data_root='data/imagenet',
+        ann_file='meta/train.txt',
+        data_prefix='train',
         pipeline=train_pipeline),
-    val=dict(
-        type=dataset_type,
-        data_prefix='data/imagenet/val',
-        ann_file='data/imagenet/meta/val.txt',
-        pipeline=test_pipeline),
-    test=dict(
-        # replace `data/val` with `data/test` for standard test
-        type=dataset_type,
-        data_prefix='data/imagenet/val',
-        ann_file='data/imagenet/meta/val.txt',
-        pipeline=test_pipeline))
+    sampler=dict(type='DefaultSampler', shuffle=True),
+)
 
-evaluation = dict(interval=10, metric='accuracy')
+val_dataloader = dict(
+    batch_size=64,
+    num_workers=8,
+    dataset=dict(
+        type=dataset_type,
+        data_root='data/imagenet',
+        ann_file='meta/val.txt',
+        data_prefix='val',
+        pipeline=test_pipeline),
+    sampler=dict(type='DefaultSampler', shuffle=False),
+)
+val_evaluator = dict(type='Accuracy', topk=(1, 5))
+
+# If you want standard test, please manually configure the test dataset
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator

--- a/configs/_base_/models/clip/clip-l-336.py
+++ b/configs/_base_/models/clip/clip-l-336.py
@@ -1,0 +1,21 @@
+# model settings
+model = dict(
+    type='ImageClassifier',
+    backbone=dict(
+        type='VisionTransformer',
+        arch='l',
+        img_size=336,
+        patch_size=14,
+        drop_rate=0.1,
+        avg_token=True,
+        output_cls_token=False,
+        pre_norm=True,
+    ),
+    neck=None,
+    head=dict(
+        type='LinearClsHead',
+        num_classes=1000,
+        in_channels=1024,
+        loss=dict(
+            type='LabelSmoothLoss', label_smooth_val=0.1, mode='original'),
+    ))

--- a/projects/clip/README.md
+++ b/projects/clip/README.md
@@ -1,0 +1,77 @@
+# CLIP
+
+[model page](../../configs/clip/README.md)
+
+## Results and models
+
+### Pre-trained Models
+
+The pre-trained models are used to fine-tune, and therefore don't have evaluation results.
+
+|                    Model                     | Pretrain | Params(M) | Flops(G) |          Config           |  Download   |
+| :------------------------------------------: | :------: | :-------: | :------: | :-----------------------: | :---------: |
+| clip-l-336-laion2b-in12k-pre_3rdparty_in1k\* |  OpenAI  |     -     |    -     | [config](./clip-l-336.py) | [model](<>) |
+
+\*Models with * are converted from the [official repo](https://github.com/mlfoundations/open_clip).
+
+## Citation
+
+```bibtex
+@software{ilharco_gabriel_2021_5143773,
+  author       = {Ilharco, Gabriel and
+                  Wortsman, Mitchell and
+                  Wightman, Ross and
+                  Gordon, Cade and
+                  Carlini, Nicholas and
+                  Taori, Rohan and
+                  Dave, Achal and
+                  Shankar, Vaishaal and
+                  Namkoong, Hongseok and
+                  Miller, John and
+                  Hajishirzi, Hannaneh and
+                  Farhadi, Ali and
+                  Schmidt, Ludwig},
+  title        = {OpenCLIP},
+  month        = jul,
+  year         = 2021,
+  note         = {If you use this software, please cite it as below.},
+  publisher    = {Zenodo},
+  version      = {0.1},
+  doi          = {10.5281/zenodo.5143773},
+  url          = {https://doi.org/10.5281/zenodo.5143773}
+}
+```
+
+```bibtex
+@inproceedings{Radford2021LearningTV,
+  title={Learning Transferable Visual Models From Natural Language Supervision},
+  author={Alec Radford and Jong Wook Kim and Chris Hallacy and A. Ramesh and Gabriel Goh and Sandhini Agarwal and Girish Sastry and Amanda Askell and Pamela Mishkin and Jack Clark and Gretchen Krueger and Ilya Sutskever},
+  booktitle={ICML},
+  year={2021}
+}
+```
+
+```bibtex
+@inproceedings{schuhmann2022laionb,
+  title={{LAION}-5B: An open large-scale dataset for training next generation image-text models},
+  author={Christoph Schuhmann and
+          Romain Beaumont and
+          Richard Vencu and
+          Cade W Gordon and
+          Ross Wightman and
+          Mehdi Cherti and
+          Theo Coombes and
+          Aarush Katta and
+          Clayton Mullis and
+          Mitchell Wortsman and
+          Patrick Schramowski and
+          Srivatsa R Kundurthy and
+          Katherine Crowson and
+          Ludwig Schmidt and
+          Robert Kaczmarczyk and
+          Jenia Jitsev},
+  booktitle={Thirty-sixth Conference on Neural Information Processing Systems Datasets and Benchmarks Track},
+  year={2022},
+  url={https://openreview.net/forum?id=M3Y74vmsMcY}
+}
+```

--- a/projects/clip/configs/clip-l-336.py
+++ b/projects/clip/configs/clip-l-336.py
@@ -1,0 +1,6 @@
+_base_ = [
+    'mmcls::_base_/models/clip/clip-l-336.py',
+    'mmcls::_base_/datasets/imagenet_bs64_clip_336.py',
+    'mmcls::_base_/schedules/imagenet_bs4096_AdamW.py',
+    'mmcls::_base_/default_runtime.py'
+]

--- a/tools/model_converters/openclip_to_mmcls.py
+++ b/tools/model_converters/openclip_to_mmcls.py
@@ -1,0 +1,92 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import argparse
+import os.path as osp
+from collections import OrderedDict
+
+import mmengine
+import torch
+
+try:
+    import open_clip
+except ImportError:
+    raise ImportError(
+        'Failed to import open_clip. Please run "pip install open_clip_torch".'
+    )
+
+
+def convert_openclip(ckpt):
+    new_ckpt = OrderedDict()
+
+    for k, v in list(ckpt.items()):
+        if 'visual' not in k:
+            continue
+        k = k.replace('visual.', '')
+        k = k.replace('transformer.', '')
+        new_v = v
+        if k.startswith('proj'):
+            new_k = 'head.fc.weight'
+            new_ckpt[new_k] = new_v.transpose(0, 1)
+            new_ckpt['head.fc.bias'] = torch.zeros(
+                new_v.transpose(0, 1).shape[0])
+            continue
+        elif k.startswith('conv1'):
+            new_k = k.replace('conv1', 'patch_embed.projection')
+        elif k.startswith('ln_pre'):
+            new_k = k.replace('ln_pre.', 'pre_norm.')
+        elif k.startswith('resblocks'):
+            new_k = k.replace('resblocks.', 'layers.')
+            if 'ln_1' in k:
+                new_k = new_k.replace('ln_1', 'ln1')
+            elif 'ln_2' in k:
+                new_k = new_k.replace('ln_2', 'ln2')
+            elif 'in_proj_weight' in k:
+                new_k = new_k.replace('in_proj_weight', 'qkv.weight')
+            elif 'in_proj_bias' in k:
+                new_k = new_k.replace('in_proj_bias', 'qkv.bias')
+            elif 'out_proj' in k:
+                new_k = new_k.replace('out_proj', 'proj')
+            elif 'mlp.c_fc' in k:
+                new_k = new_k.replace('mlp.c_fc', 'ffn.layers.0.0')
+            elif 'mlp.c_proj' in k:
+                new_k = new_k.replace('mlp.c_proj', 'ffn.layers.1')
+        elif k.startswith('class_embedding'):
+            new_v = v[None, None, :]
+            new_k = k.replace('class_embedding', 'cls_token')
+        elif k.startswith('positional_embedding'):
+            new_v = v[None, ...]
+            new_k = k.replace('positional_embedding', 'pos_embed')
+        elif k.startswith('ln_post'):
+            new_k = k.replace('ln_post', 'ln1')
+        else:
+            new_k = k
+
+        if not new_k.startswith('head'):
+            new_k = 'backbone.' + new_k
+        new_ckpt[new_k] = new_v
+    return new_ckpt
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert keys in pretrained models to mmcls style.')
+    parser.add_argument('model_name', help='open_clip model name')
+    parser.add_argument('pretrained', help='open_clip pretrained name')
+    # The dst path must be a full path of the new checkpoint.
+    parser.add_argument('dst', help='save path')
+    args = parser.parse_args()
+
+    # load torch.jit model weights
+    model, _, transform = open_clip.create_model_and_transforms(
+        model_name=args.model_name, pretrained=args.pretrained)
+    state_dict = model.state_dict()
+
+    weight = convert_openclip(state_dict)
+    mmengine.mkdir_or_exist(osp.dirname(args.dst))
+    print(weight['backbone.pos_embed'].shape)
+    torch.save(dict(state_dict=weight), args.dst)
+
+    print('Done!!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Motivation

Add OpenAI's CLIP for down stream task.
Eventually, we aim to support zero shot inferences using clips.

## Modification

```
pip install open_clip_torch
python3 tools/model_converters/openclip_to_mmcls.py ViT-L-14-336 openai ViT-L-14-336px.pth
```

I have uploaded the weights here. https://github.com/okotaku/clshub-weights/releases/download/v0.1.1clip/ViT-L-14-336px.pth

## Question

In clip weights, there is a projection parameter that is used after pooling.

https://github.com/mlfoundations/open_clip/blob/72ad6ccb2782ed7069189ff8db39647c13e55869/src/open_clip/transformer.py#L391
https://github.com/mlfoundations/open_clip/blob/72ad6ccb2782ed7069189ff8db39647c13e55869/src/open_clip/transformer.py#L496

In timm, this was treated as a head, so I implemented it accordingly.

https://github.com/huggingface/pytorch-image-models/blob/main/timm/models/vision_transformer.py#L777-L780

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
