### PR TITLE
[Improve] Use PyTorch official `scaled_dot_product_attention` to accelerate `MultiheadAttention`.

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -207,8 +207,8 @@ workflows:
             - lint
       - build_cpu_with_3rdparty:
           name: maximum_version_cpu
-          torch: 1.13.0
-          torchvision: 0.14.0
+          torch: 2.0.0
+          torchvision: 0.15.0
           python: 3.10.0
           requires:
             - minimum_version_cpu

--- a/mmpretrain/models/backbones/twins.py
+++ b/mmpretrain/models/backbones/twins.py
@@ -95,11 +95,10 @@ class GlobalSubsampledAttention(MultiheadAttention):
                                 self.head_dims).permute(2, 0, 3, 1, 4)
         k, v = kv[0], kv[1]
 
-        attn = (q @ k.transpose(-2, -1)) * self.scale
-        attn = attn.softmax(dim=-1)
-        attn = self.attn_drop(attn)
+        attn_drop = self.attn_drop if self.training else 0.
+        x = self.scaled_dot_product_attention(q, k, v, dropout_p=attn_drop)
+        x = x.transpose(1, 2).reshape(B, N, self.embed_dims)
 
-        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
         x = self.proj(x)
         x = self.out_drop(self.proj_drop(x))
 

--- a/mmpretrain/models/utils/attention.py
+++ b/mmpretrain/models/utils/attention.py
@@ -25,6 +25,34 @@ else:
     torch_meshgrid = torch.meshgrid
 
 
+def scaled_dot_product_attention_pyimpl(query,
+                                        key,
+                                        value,
+                                        attn_mask=None,
+                                        dropout_p=0.,
+                                        scale=None,
+                                        is_causal=False):
+    scale = scale or query.size(-1)**0.5
+    if is_causal and attn_mask is not None:
+        attn_mask = torch.ones(
+            query.size(-2), key.size(-2), dtype=torch.bool).tril(diagonal=0)
+    if attn_mask is not None and attn_mask.dtype == torch.bool:
+        attn_mask = attn_mask.masked_fill(not attn_mask, -float('inf'))
+
+    attn_weight = query @ key.transpose(-2, -1) / scale
+    if attn_mask is not None:
+        attn_weight += attn_mask
+    attn_weight = torch.softmax(attn_weight, dim=-1)
+    attn_weight = torch.dropout(attn_weight, dropout_p, True)
+    return attn_weight @ value
+
+
+if digit_version(torch.__version__) >= digit_version('2.0.0'):
+    scaled_dot_product_attention = F.scaled_dot_product_attention
+else:
+    scaled_dot_product_attention = scaled_dot_product_attention_pyimpl
+
+
 class WindowMSA(BaseModule):
     """Window based multi-head self-attention (W-MSA) module with relative
     position bias.
@@ -525,10 +553,15 @@ class MultiheadAttention(BaseModule):
         self.v_shortcut = v_shortcut
 
         self.head_dims = embed_dims // num_heads
-        self.scale = qk_scale or self.head_dims**-0.5
+        if qk_scale is not None:
+            self.scaled_dot_product_attention = partial(
+                scaled_dot_product_attention_pyimpl,
+                scale=self.head_dims**-0.5)
+        else:
+            self.scaled_dot_product_attention = scaled_dot_product_attention
 
         self.qkv = nn.Linear(self.input_dims, embed_dims * 3, bias=qkv_bias)
-        self.attn_drop = nn.Dropout(attn_drop)
+        self.attn_drop = attn_drop
         self.proj = nn.Linear(embed_dims, embed_dims, bias=proj_bias)
         self.proj_drop = nn.Dropout(proj_drop)
 
@@ -545,11 +578,10 @@ class MultiheadAttention(BaseModule):
                                   self.head_dims).permute(2, 0, 3, 1, 4)
         q, k, v = qkv[0], qkv[1], qkv[2]
 
-        attn = (q @ k.transpose(-2, -1)) * self.scale
-        attn = attn.softmax(dim=-1)
-        attn = self.attn_drop(attn)
+        attn_drop = self.attn_drop if self.training else 0.
+        x = self.scaled_dot_product_attention(q, k, v, dropout_p=attn_drop)
+        x = x.transpose(1, 2).reshape(B, N, self.embed_dims)
 
-        x = (attn @ v).transpose(1, 2).reshape(B, N, self.embed_dims)
         x = self.proj(x)
         x = self.out_drop(self.gamma1(self.proj_drop(x)))
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -35,6 +35,10 @@ def parse_args():
         'Note that the quotation marks are necessary and that no white space '
         'is allowed.')
     parser.add_argument(
+        '--amp',
+        action='store_true',
+        help='enable automatic-mixed-precision test')
+    parser.add_argument(
         '--show-dir',
         help='directory where the visualization images will be saved.')
     parser.add_argument(
@@ -67,7 +71,10 @@ def parse_args():
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
         help='job launcher')
-    parser.add_argument('--local_rank', type=int, default=0)
+    # When using PyTorch version >= 2.0.0, the `torch.distributed.launch`
+    # will pass the `--local-rank` parameter to `tools/train.py` instead
+    # of `--local_rank`.
+    parser.add_argument('--local_rank', '--local-rank', type=int, default=0)
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)
@@ -88,6 +95,10 @@ def merge_args(cfg, args):
                                 osp.splitext(osp.basename(args.config))[0])
 
     cfg.load_from = args.checkpoint
+
+    # enable automatic-mixed-precision test
+    if args.amp:
+        cfg.test_cfg.fp16 = True
 
     # -------------------- visualization --------------------
     if args.show or (args.show_dir is not None):

--- a/tools/train.py
+++ b/tools/train.py
@@ -59,7 +59,10 @@ def parse_args():
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
         help='job launcher')
-    parser.add_argument('--local_rank', type=int, default=0)
+    # When using PyTorch version >= 2.0.0, the `torch.distributed.launch`
+    # will pass the `--local-rank` parameter to `tools/train.py` instead
+    # of `--local_rank`.
+    parser.add_argument('--local_rank', '--local-rank', type=int, default=0)
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)


### PR DESCRIPTION
## Motivation

Pytorch 2.0 has official `scaled_dot_product_attention` implementation, which will automatically select the
attention implementation like `FlashAttention` and `Memory-Efficient Attention`.

## Modification

If the PyTorch version is higher than 2.0, use the official `scaled_dot_product_attention` in the
`MultiheadAttention`.

## Use cases

Here is the speed comparsion on test (NVIDIA A100, FP16):

**Original**:

```text
03/23 12:19:48 - mmengine - INFO - Epoch(test) [10/98]    eta: 0:02:17  time: 1.5650  data_time: 0.5420  memory: 4155  
03/23 12:19:52 - mmengine - INFO - Epoch(test) [20/98]    eta: 0:01:14  time: 0.3493  data_time: 0.0018  memory: 4155  
03/23 12:19:55 - mmengine - INFO - Epoch(test) [30/98]    eta: 0:00:51  time: 0.3411  data_time: 0.0014  memory: 4155  
03/23 12:19:58 - mmengine - INFO - Epoch(test) [40/98]    eta: 0:00:36  time: 0.2472  data_time: 0.0016  memory: 4155  
03/23 12:20:00 - mmengine - INFO - Epoch(test) [50/98]    eta: 0:00:26  time: 0.2463  data_time: 0.0014  memory: 4155  
03/23 12:20:03 - mmengine - INFO - Epoch(test) [60/98]    eta: 0:00:18  time: 0.2463  data_time: 0.0011  memory: 4155  
03/23 12:20:05 - mmengine - INFO - Epoch(test) [70/98]    eta: 0:00:12  time: 0.2462  data_time: 0.0010  memory: 4155  
03/23 12:20:08 - mmengine - INFO - Epoch(test) [80/98]    eta: 0:00:07  time: 0.2463  data_time: 0.0010  memory: 4155  
03/23 12:20:10 - mmengine - INFO - Epoch(test) [90/98]    eta: 0:00:03  time: 0.2471  data_time: 0.0010  memory: 4155  
03/23 12:20:13 - mmengine - INFO - Epoch(test) [98/98]  accuracy/top1: 82.3800  accuracy/top5: 96.1480
```

**New** (Use flash-attention):

```text
03/23 12:18:33 - mmengine - INFO - Epoch(test) [10/98]    eta: 0:02:07  time: 1.4518  data_time: 0.6494  memory: 3538  
03/23 12:18:36 - mmengine - INFO - Epoch(test) [20/98]    eta: 0:01:07  time: 0.2795  data_time: 0.0016  memory: 3538  
03/23 12:18:38 - mmengine - INFO - Epoch(test) [30/98]    eta: 0:00:43  time: 0.1712  data_time: 0.0014  memory: 3538  
03/23 12:18:40 - mmengine - INFO - Epoch(test) [40/98]    eta: 0:00:30  time: 0.1957  data_time: 0.0012  memory: 3538  
03/23 12:18:41 - mmengine - INFO - Epoch(test) [50/98]    eta: 0:00:21  time: 0.1711  data_time: 0.0011  memory: 3538  
03/23 12:18:43 - mmengine - INFO - Epoch(test) [60/98]    eta: 0:00:15  time: 0.1705  data_time: 0.0010  memory: 3538  
03/23 12:18:45 - mmengine - INFO - Epoch(test) [70/98]    eta: 0:00:10  time: 0.1708  data_time: 0.0010  memory: 3538  
03/23 12:18:46 - mmengine - INFO - Epoch(test) [80/98]    eta: 0:00:06  time: 0.1706  data_time: 0.0009  memory: 3538  
03/23 12:18:48 - mmengine - INFO - Epoch(test) [90/98]    eta: 0:00:02  time: 0.1747  data_time: 0.0009  memory: 3538  
03/23 12:18:50 - mmengine - INFO - Epoch(test) [98/98]  accuracy/top1: 82.3820  accuracy/top5: 96.1500
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
