### PR TITLE
fix register torchvision.transforms error

### DIFF
--- a/configs/efficientnet_v2/metafile.yml
+++ b/configs/efficientnet_v2/metafile.yml
@@ -17,7 +17,7 @@ Collections:
       Title: "EfficientNetV2: Smaller Models and Faster Training"
     README: configs/efficientnet_v2/README.md
     Code:
-      URL: https://github.com/open-mmlab/mmpretrain/blob/main/mmpretrain/models/backbones/beit.py
+      URL: https://github.com/open-mmlab/mmpretrain/blob/main/mmpretrain/models/backbones/efficientnet_v2.py
       Version: v1.0.0rc4
 
 Models:

--- a/mmpretrain/datasets/transforms/processing.py
+++ b/mmpretrain/datasets/transforms/processing.py
@@ -82,10 +82,8 @@ def register_vision_transforms() -> List[str]:
         _transform = getattr(torchvision.transforms, module_name)
         if inspect.isclass(_transform) and callable(
                 _transform) and not isinstance(_transform, (EnumMeta)):
-            from functools import partial
             TRANSFORMS.register_module(
-                module=partial(
-                    TorchVisonTransformWrapper, transform=_transform),
+                module=lambda name=module_name: TorchVisonTransformWrapper(transform=torchvision.transforms[name], name=name),
                 name=f'torchvision/{module_name}')
             vision_transforms.append(f'torchvision/{module_name}')
     return vision_transforms

--- a/mmpretrain/datasets/transforms/processing.py
+++ b/mmpretrain/datasets/transforms/processing.py
@@ -83,7 +83,8 @@ def register_vision_transforms() -> List[str]:
         if inspect.isclass(_transform) and callable(
                 _transform) and not isinstance(_transform, (EnumMeta)):
             TRANSFORMS.register_module(
-                module=lambda name=module_name: TorchVisonTransformWrapper(transform=torchvision.transforms[name], name=name),
+                module=lambda name=module_name: TorchVisonTransformWrapper(
+                    transform=torchvision.transforms[name], name=name),
                 name=f'torchvision/{module_name}')
             vision_transforms.append(f'torchvision/{module_name}')
     return vision_transforms


### PR DESCRIPTION
 AttributeError: 'functools.partial' object has no attribute '__module__' when call mmengine.registry.count_registered_modules(./)

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

when i run code
```
from mmengine.registry import traverse_registry_tree, count_registered_modules
from mmpretrain.utils import register_all_modules as register_all_mmpretrain_modules


if __name__ == "__main__":
    register_all_mmpretrain_modules()
    count_registered_modules("./")

```
error blow
```
11/01 14:43:05 - mmengine - INFO - Find 3 modules in mmengine's 'dataset' registry 
11/01 14:43:05 - mmengine - INFO - Find 24 modules in mmpretrain's 'dataset' registry 
11/01 14:43:05 - mmengine - INFO - Find 36 modules in mmdet's 'dataset' registry 
11/01 14:43:05 - mmengine - INFO - Find 3 modules in mmengine's 'data sampler' registry 
11/01 14:43:05 - mmengine - INFO - Find 2 modules in mmpretrain's 'data sampler' registry 
11/01 14:43:05 - mmengine - INFO - Find 8 modules in mmdet's 'data sampler' registry 
11/01 14:43:05 - mmengine - INFO - Find 2 modules in mmengine's 'evaluator' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmpretrain's 'evaluator' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'evaluator' registry 
11/01 14:43:05 - mmengine - INFO - Find 2 modules in mmengine's 'function' registry 
11/01 14:43:05 - mmengine - INFO - Find 15 modules in mmengine's 'hook' registry 
11/01 14:43:05 - mmengine - INFO - Find 11 modules in mmpretrain's 'hook' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'hook' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmengine's 'inferencer' registry 
11/01 14:43:05 - mmengine - INFO - Find 1 modules in mmengine's 'log_processor' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmpretrain's 'log processor' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'log_processor' registry 
11/01 14:43:05 - mmengine - INFO - Find 4 modules in mmengine's 'loop' registry 
11/01 14:43:05 - mmengine - INFO - Find 2 modules in mmpretrain's 'loop' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'loop' registry 
11/01 14:43:05 - mmengine - INFO - Find 1 modules in mmengine's 'metric' registry 
11/01 14:43:05 - mmengine - INFO - Find 19 modules in mmpretrain's 'metric' registry 
11/01 14:43:05 - mmengine - INFO - Find 24 modules in mmdet's 'metric' registry 
11/01 14:43:05 - mmengine - INFO - Find 77 modules in mmengine's 'model' registry 
11/01 14:43:05 - mmengine - INFO - Find 197 modules in mmpretrain's 'model' registry 
11/01 14:43:05 - mmengine - INFO - Find 278 modules in mmdet's 'model' registry 
11/01 14:43:05 - mmengine - INFO - Find 7 modules in mmengine's 'model_wrapper' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmpretrain's 'model_wrapper' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'model_wrapper' registry 
11/01 14:43:05 - mmengine - INFO - Find 15 modules in mmengine's 'optimizer' registry 
11/01 14:43:05 - mmengine - INFO - Find 3 modules in mmpretrain's 'optimizer' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'optimizer' registry 
11/01 14:43:05 - mmengine - INFO - Find 5 modules in mmengine's 'optim_wrapper' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmpretrain's 'optimizer_wrapper' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'optim_wrapper' registry 
11/01 14:43:05 - mmengine - INFO - Find 1 modules in mmengine's 'optimizer wrapper constructor' registry 
11/01 14:43:05 - mmengine - INFO - Find 1 modules in mmpretrain's 'optimizer wrapper constructor' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'optimizer constructor' registry 
11/01 14:43:05 - mmengine - INFO - Find 29 modules in mmengine's 'parameter scheduler' registry 
11/01 14:43:05 - mmengine - INFO - Find 1 modules in mmpretrain's 'parameter scheduler' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'parameter scheduler' registry 
11/01 14:43:05 - mmengine - INFO - Find 2 modules in mmengine's 'runner' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmpretrain's 'runner' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'runner' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmengine's 'runner constructor' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmpretrain's 'runner constructor' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmdet's 'runner constructor' registry 
11/01 14:43:05 - mmengine - INFO - Find 4 modules in mmengine's 'strategy' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmengine's 'task util' registry 
11/01 14:43:05 - mmengine - INFO - Find 0 modules in mmpretrain's 'task util' registry 
11/01 14:43:05 - mmengine - INFO - Find 51 modules in mmdet's 'task util' registry 
11/01 14:43:05 - mmengine - INFO - Find 19 modules in mmengine's 'transform' registry 
Traceback (most recent call last):
  File "/root/anaconda3/envs/mmdlp/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/root/anaconda3/envs/mmdlp/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/root/.vscode-server/extensions/ms-python.debugpy-2024.12.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 71, in <module>
    cli.main()
  File "/root/.vscode-server/extensions/ms-python.debugpy-2024.12.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 501, in main
    run()
  File "/root/.vscode-server/extensions/ms-python.debugpy-2024.12.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 351, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/root/.vscode-server/extensions/ms-python.debugpy-2024.12.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 310, in run_path
    return _run_module_code(code, init_globals, run_name, pkg_name=pkg_name, script_name=fname)
  File "/root/.vscode-server/extensions/ms-python.debugpy-2024.12.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 127, in _run_module_code
    _run_code(code, mod_globals, init_globals, mod_name, mod_spec, pkg_name, script_name)
  File "/root/.vscode-server/extensions/ms-python.debugpy-2024.12.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 118, in _run_code
    exec(code, run_globals)
  File "/root/data/mmdlp/tools/traverse_registry.py", line 15, in <module>
    count_registered_modules("./")
  File "/root/anaconda3/envs/mmdlp/lib/python3.8/site-packages/mmengine/registry/utils.py", line 82, in count_registered_modules
    registries_info[item] = traverse_registry_tree(
  File "/root/anaconda3/envs/mmdlp/lib/python3.8/site-packages/mmengine/registry/utils.py", line 51, in traverse_registry_tree
    _dfs_registry(root_registry)
  File "/root/anaconda3/envs/mmdlp/lib/python3.8/site-packages/mmengine/registry/utils.py", line 49, in _dfs_registry
    _dfs_registry(child)
  File "/root/anaconda3/envs/mmdlp/lib/python3.8/site-packages/mmengine/registry/utils.py", line 35, in _dfs_registry
    folder = '/'.join(registered_class.__module__.split('.')[:-1])
AttributeError: 'functools.partial' object has no attribute '__module__'
```

## Modification
modify function register_vision_transforms in mmpretrain.datasets.transforms.processing.py,   from partial to lambda

```
def register_vision_transforms() -> List[str]:
    """Register transforms in ``torchvision.transforms`` to the ``TRANSFORMS``
    registry.

    Returns:
        List[str]: A list of registered transforms' name.
    """
    vision_transforms = []
    for module_name in dir(torchvision.transforms):
        if not re.match('[A-Z]', module_name):
            # must startswith a capital letter
            continue
        _transform = getattr(torchvision.transforms, module_name)
        if inspect.isclass(_transform) and callable(
                _transform) and not isinstance(_transform, (EnumMeta)):
            #from functools import partial
            TRANSFORMS.register_module(
                module=lambda name=module_name: TorchVisonTransformWrapper(transform=torchvision.transforms[name], name=name),
                name=f'torchvision/{module_name}')
            # TRANSFORMS.register_module(
                # module=partial(
                    # TorchVisonTransformWrapper, transform=_transform),
                # name=f'torchvision/{module_name}')
            vision_transforms.append(f'torchvision/{module_name}')
    return vision_transforms
```
Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
